### PR TITLE
Move setup_default_parts into Parted module

### DIFF
--- a/app/models/business_support_edition.rb
+++ b/app/models/business_support_edition.rb
@@ -3,9 +3,8 @@ require "parted"
 
 class BusinessSupportEdition < Edition
   include Parted
-  validate :min_must_be_less_than_max
 
-  before_save :setup_default_parts, on: :create
+  validate :min_must_be_less_than_max
 
   field :short_description, type: String
   field :min_value, type: Integer
@@ -18,12 +17,8 @@ class BusinessSupportEdition < Edition
     {title: "Additional information", slug: "additional-information"}
   ]
 
-  def setup_default_parts
-    if parts.empty?
-      DEFAULT_PARTS.each do |part|
-        parts.build(title: part[:title], slug: part[:slug], body: "")
-      end
-    end
+  set_callback(:create, :before) do |document|
+    setup_default_parts(DEFAULT_PARTS)
   end
 
   private

--- a/app/models/parted.rb
+++ b/app/models/parted.rb
@@ -29,4 +29,12 @@ module Parted
   def whole_body
     self.parts.map {|i| %Q{\# #{i.title}\n\n#{i.body}} }.join("\n\n")
   end
+
+  def setup_default_parts(default_parts)
+    if self.parts.empty?
+      default_parts.each { |part|
+        self.parts.build(title: part[:title], slug: part[:slug], body: "")
+      }
+    end
+  end
 end

--- a/app/models/programme_edition.rb
+++ b/app/models/programme_edition.rb
@@ -3,8 +3,6 @@ require "parted"
 class ProgrammeEdition < Edition
   include Parted
 
-  before_save :setup_default_parts, on: :create
-
   @fields_to_clone = []
 
   DEFAULT_PARTS = [
@@ -15,11 +13,7 @@ class ProgrammeEdition < Edition
     {title: "Further information", slug: "further-information"},
   ]
 
-  def setup_default_parts
-    if parts.empty?
-      DEFAULT_PARTS.each { |part|
-        parts.build(title: part[:title], slug: part[:slug], body: "")
-      }
-    end
+  set_callback(:create, :before) do |document|
+    setup_default_parts(DEFAULT_PARTS)
   end
 end


### PR DESCRIPTION
There are common cases for Parted Editions where some default setup of parts is required.

Instead of handling this at the class level, let the Parted module hold the relevant code.

Also, use the new ActiveSupport callback style for before_create.
