### PR TITLE
Expose tags and tag_ids in json view of Artefact

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -115,9 +115,10 @@ class Artefact
       include: {contact: {}}
     )).tap { |hash|
       if hash["tag_ids"]
-        hash["tag_ids"] = hash["tag_ids"].map { |tag_id| TagRepository.load(tag_id).as_json }
+        hash["tags"] = hash["tag_ids"].map { |tag_id| TagRepository.load(tag_id).as_json }
       else
-        hash.delete "tag_ids"
+        hash["tag_ids"] = []
+        hash["tags"] = []
       end
 
       if self.primary_section


### PR DESCRIPTION
This will be helpful because in a lot of cases in frontend apps we'll just care whether a tag is set or not.  e.g. for the legacy sources, we only care if the directgov or businesslink tag is set.

Exposing the tag_ids as well as the tags will allow us to do:

``` ruby
if artefact["tag_ids"].include?('businesslink')
  do_stuff
end
```

This change also ensures that an empty array is returned if there are no tags.
