### PR TITLE
Add the 'completed transaction' format

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -223,6 +223,10 @@ class Artefact
     self.state == "live"
   end
 
+  def indexable?
+    self.kind != "completed_transaction"
+  end
+
   def snapshot
     reconcile_tag_ids
     attributes.except "_id", "created_at", "updated_at", "actions"

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -52,6 +52,7 @@ class Artefact
     "programme",
     "local_transaction",
     "transaction",
+    "completed_transaction",
     "place",
     "smart-answer",
     "custom-application",
@@ -63,6 +64,7 @@ class Artefact
   KIND_TRANSLATIONS = {
     "standard transaction link"        => "transaction",
     "local authority transaction link" => "local_transaction",
+    "completed/done transaction" => "completed_transaction",
     "benefit / scheme"                 => "programme",
     "find my nearest"                  => "place",
   }.tap { |h| h.default_proc = -> _, k { k } }.freeze

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -223,10 +223,6 @@ class Artefact
     self.state == "live"
   end
 
-  def indexable?
-    self.kind != "completed_transaction"
-  end
-
   def snapshot
     reconcile_tag_ids
     attributes.except "_id", "created_at", "updated_at", "actions"

--- a/app/models/completed_transaction_edition.rb
+++ b/app/models/completed_transaction_edition.rb
@@ -1,0 +1,13 @@
+require "edition"
+require "safe_html"
+
+class CompletedTransactionEdition < Edition
+  field :body, type: String
+
+  @fields_to_clone = [:body]
+
+  def whole_body
+    self.body
+  end
+
+end

--- a/app/validators/slug_validator.rb
+++ b/app/validators/slug_validator.rb
@@ -1,6 +1,11 @@
 class SlugValidator < ActiveModel::EachValidator
   # implement the method called during validation
   def validate_each(record, attribute, value)
+    # allow slugs to have the done/ prefix
+    if value.to_s =~ /^done\/(.+)/
+      value = $1
+    end
+
     unless ActiveSupport::Inflector.parameterize(value.to_s) == value.to_s
       record.errors[attribute] << "must be usable in a URL"
     end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -19,6 +19,18 @@ class ArtefactTest < ActiveSupport::TestCase
     assert a.errors[:slug].any?
   end
 
+  test "it allows slashes in slugs when the namespace is 'done'" do
+    a = Artefact.new(slug: "done/its-a-nice-day")
+    refute a.valid?
+    assert a.errors[:slug].empty?
+  end
+
+  test "it doesn't allow slashes in slugs when the namespace is not 'done'" do
+    a = Artefact.new(slug: "something-else/its-a-nice-day")
+    refute a.valid?
+    assert a.errors[:slug].any?
+  end
+
   test "should translate kind into internally normalised form" do
     a = Artefact.new(kind: "benefit / scheme")
     a.normalise


### PR DESCRIPTION
Add the completed transaction format for 'done' pages.

Slashes are now valid in slugs, only if the prefix of the URL is 'done'.

Also, marking all artefacts as 'indexable' by default. A change to panopticon will ensure that only indexable artefacts get added to the search index. We override this with the completed transaction as we do not want these items of content to be added to search or browse pages.
