### PR TITLE
Don't validate fact check email contents

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -138,6 +138,11 @@ module Workflow
     actions.create!(options.merge(requester_id: user.id, request_type: type))
   end
 
+  def new_action_without_validation(user, type, options={})
+    actions.build(options.merge(requester_id: user.id, request_type: type))
+    save(validate: false)
+  end
+
   def most_recent_action(&blk)
     self.actions.sort_by(&:created_at).reverse.find(&blk)
   end

--- a/app/models/workflow_actor.rb
+++ b/app/models/workflow_actor.rb
@@ -16,6 +16,13 @@ module WorkflowActor
     action
   end
 
+  def record_action_without_validation(edition, type, options={})
+    type = Action.const_get(type.to_s.upcase)
+    action = edition.new_action_without_validation(self, type, options)
+    edition.save! # force callbacks for denormalisation
+    action
+  end
+
   def can_take_action(action, edition)
     respond_to?(:"can_#{action}?") ? __send__(:"can_#{action}?", edition) : true
   end
@@ -86,7 +93,9 @@ module WorkflowActor
   # Always records the action.
   def receive_fact_check(edition, details)
     edition.receive_fact_check
-    record_action(edition, :receive_fact_check, details)
+    # Fact checks are processed async, so the user doesn't get an opportunity
+    # to retry without the content that (inadvertantly) fails validation, which happens frequently.
+    record_action_without_validation(edition, :receive_fact_check, details)
   end
 
   def skip_fact_check(edition, details)

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -149,6 +149,22 @@ class WorkflowTest < ActiveSupport::TestCase
     assert edition.actions.detect { |e| e.request_type == 'skip_fact_check' }
   end
 
+  # until we improve the validation to produce few or no false positives
+  test "when processing fact check, it is not validated" do
+    user = User.create(name: "Ben")
+    other_user = User.create(name: "James")
+
+    guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title", alternative_title: "My Other Title")
+    edition = guide
+    user.start_work(edition)
+    user.request_review(edition,{comment: "Review this guide please."})
+    other_user.approve_review(edition, {comment: "I've reviewed it"})
+    user.send_fact_check(edition,{comment: "Review this guide please.", email_addresses: "test@test.com"})
+    user.receive_fact_check(edition, {comment: "Text.<l>content that the SafeHtml validator would catch</l>"})
+
+    assert_equal "Text.<l>content that the SafeHtml validator would catch</l>", edition.actions.last.comment
+  end
+
   test "check counting reviews" do
     user = User.create(name: "Ben")
     other_user = User.create(name: "James")


### PR DESCRIPTION
Intended as temporary until we can improve the validation.

Fact check emails frequently contain content that, especially once
govspeaked, is rejected by the current Govspeak::HtmlValidator (but
isn't malicious). I believe this means that content editors can't see the 
feedback from fact checking, and therefore can't really progress such 
an edition.
