### PR TITLE
Default html validation not govspeak

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -37,7 +37,8 @@ class Action
   field :customised_message, type: String
   field :created_at,         type: DateTime, default: lambda { Time.now }
 
-  validates_with SafeHtml, govspeak_fields: []
+  GOVSPEAK_FIELDS = []
+  validates_with SafeHtml
 
   def container_class_name(edition)
     edition.container.class.name.underscore.humanize

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -42,7 +42,9 @@ class Artefact
   field "state",                type: String,  default: "draft"
   field "specialist_body",      type: String
 
-  validates_with SafeHtml, govspeak_fields: []
+  GOVSPEAK_FIELDS = []
+  
+  validates_with SafeHtml
 
   MAXIMUM_RELATED_ITEMS = 8
 

--- a/app/models/artefact_action.rb
+++ b/app/models/artefact_action.rb
@@ -5,9 +5,11 @@ class ArtefactAction
   field "action_type", type: String
   field "snapshot", type: Hash
 
+  GOVSPEAK_FIELDS = []
+
   embedded_in :artefact
 
-  validates_with SafeHtml, govspeak_fields: []
+  validates_with SafeHtml
 
   # Ideally we would like to use the UID field here, since that will be the
   # same across all applications, but Mongoid doesn't yet support using a

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -13,7 +13,9 @@ class Contact
   field "contactotron_id", type: Integer
   field "phone_numbers",   type: Array
 
-  validates_with SafeHtml, govspeak_fields: []
+  GOVSPEAK_FIELDS = []
+  
+  validates_with SafeHtml
   validates :name, presence: true
 
   def update_from_contactotron

--- a/app/models/curated_list.rb
+++ b/app/models/curated_list.rb
@@ -13,8 +13,10 @@ class CuratedList
 
   index "slug"
 
+  GOVSPEAK_FIELDS = []
+
   validates :slug, presence: true, uniqueness: true, slug: true
-  validates_with SafeHtml, govspeak_fields: []
+  validates_with SafeHtml
 
   def self.find_by_slug(slug)
     where(slug: slug).first

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -26,6 +26,10 @@ class Edition
   field :publisher,            type: String
   field :archiver,             type: String
 
+  GOVSPEAK_FIELDS = [:body, :overview, :more_information, :short_description, :introduction, 
+      :licence_short_description, :licence_overview, :eligibility, 
+      :evaluation, :additional_information]
+
   belongs_to :assigned_to, class_name: "User"
 
   scope :lined_up,            where(state: "lined_up")
@@ -49,7 +53,7 @@ class Edition
   validates :title, presence: true
   validates :version_number, presence: true
   validates :panopticon_id, presence: true
-  validates_with SafeHtml, govspeak_fields: [:body, :overview, :more_information, :short_description, :introduction, :licence_short_description, :licence_overview, :eligibility, :evaluation, :additional_information]
+  validates_with SafeHtml
 
   before_save :check_for_archived_artefact
   before_destroy :destroy_artefact

--- a/app/models/expectation.rb
+++ b/app/models/expectation.rb
@@ -4,5 +4,7 @@ class Expectation
 
   field :text,      type: String
 
-  validates_with SafeHtml, govspeak_fields: []
+  GOVSPEAK_FIELDS = []
+
+  validates_with SafeHtml
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -16,9 +16,11 @@ class LocalAuthority
   field :contact_phone,      type: String
   field :contact_email,      type: String
 
+  GOVSPEAK_FIELDS = []
+
   validates_uniqueness_of :snac, :local_directgov_id
   validates_presence_of   :snac, :local_directgov_id, :name, :tier
-  validates_with SafeHtml, govspeak_fields: []
+  validates_with SafeHtml
 
   scope :for_snacs, ->(snacs) { any_in(snac: snacs) }
 

--- a/app/models/local_interaction.rb
+++ b/app/models/local_interaction.rb
@@ -9,8 +9,10 @@ class LocalInteraction
   field :lgil_code, type: Integer
   field :url,       type: String
 
+  GOVSPEAK_FIELDS = []
+
   embedded_in :local_authority
 
   validates_presence_of :url, :lgil_code, :lgsl_code
-  validates_with SafeHtml, govspeak_fields: []
+  validates_with SafeHtml
 end

--- a/app/models/local_service.rb
+++ b/app/models/local_service.rb
@@ -8,12 +8,14 @@ class LocalService
   field :lgsl_code,      type: Integer
   field :providing_tier, type: Array
 
+  GOVSPEAK_FIELDS = []
+
   validates_presence_of :lgsl_code, :providing_tier
   validates_uniqueness_of :lgsl_code
   validates :providing_tier, inclusion: {
     in: [%w{county unitary}, %w{district unitary}, %w{district unitary county}]
   }
-  validates_with SafeHtml, govspeak_fields: []
+  validates_with SafeHtml
 
   def self.find_by_lgsl_code(lgsl_code)
     LocalService.where(lgsl_code: lgsl_code).first

--- a/app/models/overview_dashboard.rb
+++ b/app/models/overview_dashboard.rb
@@ -17,5 +17,7 @@ class OverviewDashboard
   field :published,           type: Integer
   field :archived,            type: Integer
 
-  validates_with SafeHtml, govspeak_fields: []
+  GOVSPEAK_FIELDS = []
+
+  validates_with SafeHtml
 end

--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -13,9 +13,11 @@ class Part
   field :slug,       type: String
   field :created_at, type: DateTime, default: lambda { Time.now }
 
+  GOVSPEAK_FIELDS = []
+
   validates_presence_of :title
   validates_presence_of :slug
   validates_exclusion_of :slug, in: ["video"], message: "Can not be video"
   validates_format_of :slug, with: /^[a-z0-9\-]+$/i
-  validates_with SafeHtml, govspeak_fields: []
+  validates_with SafeHtml
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -9,11 +9,13 @@ class Tag
 
   field :parent_id, type: String
 
+  GOVSPEAK_FIELDS = []
+
   index :tag_id, unique: true
   index :tag_type
 
   validates_presence_of :tag_id, :title, :tag_type
-  validates_with SafeHtml, govspeak_fields: []
+  validates_with SafeHtml
 
   # This doesn't get set automatically: the code that loads tags
   # should go through them and set this attribute manually

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,8 @@ class User
   field "email",               type: String
   field "permissions",         type: Hash
   field "remotely_signed_out", type: Boolean, default: false
+  
+  GOVSPEAK_FIELDS = []
 
   # Setup accessible (or protected) attributes for your model
   attr_accessible :email, :name, :uid
@@ -29,7 +31,7 @@ class User
 
   scope :alphabetized, order_by(name: :asc)
 
-  validates_with SafeHtml, govspeak_fields: []
+  validates_with SafeHtml
 
   # GDS::SSO specifically looks for find_by_uid within warden
   # when loading authentication user from session

--- a/app/validators/safe_html.rb
+++ b/app/validators/safe_html.rb
@@ -18,7 +18,7 @@ class SafeHtml < ActiveModel::Validator
   end
 
   def check_string(record, field_name, string)
-    if govspeak_fields.include?(field_name)
+    if record.class::GOVSPEAK_FIELDS.include?(field_name)
       unless Govspeak::Document.new(string).valid?
         error = "cannot include invalid Govspeak or JavaScript"
         record.errors.add(field_name, error)
@@ -30,9 +30,4 @@ class SafeHtml < ActiveModel::Validator
       end
     end
   end
-
-  private
-    def govspeak_fields
-      options[:govspeak_fields] || []
-    end
 end

--- a/test/validators/safe_html_validator_test.rb
+++ b/test/validators/safe_html_validator_test.rb
@@ -7,7 +7,9 @@ class SafeHtmlTest < ActiveSupport::TestCase
     field "declared", type: String
     field "i_am_govspeak", type: String
 
-    validates_with SafeHtml, govspeak_fields: [:i_am_govspeak]
+    GOVSPEAK_FIELDS = [:i_am_govspeak]
+
+    validates_with SafeHtml
 
     embeds_one :dummy_embedded_single
   end
@@ -15,7 +17,9 @@ class SafeHtmlTest < ActiveSupport::TestCase
   class ::DummyEmbeddedSingle
     include Mongoid::Document
 
-    validates_with SafeHtml, govspeak_fields: []
+    GOVSPEAK_FIELDS = []
+
+    validates_with SafeHtml
 
     embedded_in :dummy
   end


### PR DESCRIPTION
This should cut down the number of false positives, because when
we process it into Govspeak there are various things which can
cause it to be (incorrectly) identified as potentially malicious.
