### PR TITLE
Tags can have short descriptions

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -6,6 +6,7 @@ class Tag
   field :title,    type: String
   field :tag_type, type: String #TODO: list of accepted types?
   field :description, type: String
+  field :short_description, type: String
 
   field :parent_id, type: String
 
@@ -24,7 +25,8 @@ class Tag
       id: self.tag_id,
       title: self.title,
       type: self.tag_type,
-      description: self.description
+      description: self.description,
+      short_description: self.short_description
     }
   end
 

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -258,13 +258,15 @@ class ArtefactTest < ActiveSupport::TestCase
               :id => 'justice',
               :title => 'Justice',
               :type => 'section',
-              :description => 'All about justice'
+              :description => 'All about justice',
+              :short_description => nil
             },
             {
               :id => 'businesslink',
               :title => 'Business Link',
               :type => 'legacy_source',
-              :description => nil
+              :description => nil,
+              :short_description => nil
             }
           ]
           assert_equal expected, hash['tags']

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -11,7 +11,8 @@ class TagTest < ActiveSupport::TestCase
       id: "crime",
       title: "Crime",
       type: "section",
-      description: nil
+      description: nil,
+      short_description: nil
     }
     assert_equal expected_hash, tag.as_json
   end


### PR DESCRIPTION
As part of the work to enable the homepage (frontend) to populate the
sections it has we need tags to have short descriptions.

This is because the current descriptions, while useful, are too long to
fit on the homepage. As a result these tags will have a shorter
description to go with their long-form description.
