### PR TITLE
Refine which fields are govspeak

### DIFF
--- a/app/models/answer_edition.rb
+++ b/app/models/answer_edition.rb
@@ -4,6 +4,8 @@ require "safe_html"
 class AnswerEdition < Edition
   field :body, type: String
 
+  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body]
+
   @fields_to_clone = [:body]
 
   def indexable_content

--- a/app/models/business_support_edition.rb
+++ b/app/models/business_support_edition.rb
@@ -17,6 +17,8 @@ class BusinessSupportEdition < Edition
   field :business_support_identifier, type: String
   index :business_support_identifier
 
+  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body, :eligibility, :evaluation, :additional_information]
+
   validate :min_must_be_less_than_max
   validates :business_support_identifier, :presence => true
   validate :business_support_identifier_unique

--- a/app/models/completed_transaction_edition.rb
+++ b/app/models/completed_transaction_edition.rb
@@ -4,6 +4,8 @@ require "safe_html"
 class CompletedTransactionEdition < Edition
   field :body, type: String
 
+  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body]
+
   @fields_to_clone = [:body]
 
   def whole_body

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -26,9 +26,7 @@ class Edition
   field :publisher,            type: String
   field :archiver,             type: String
 
-  GOVSPEAK_FIELDS = [:body, :overview, :more_information, :short_description, :introduction, 
-      :licence_short_description, :licence_overview, :eligibility, 
-      :evaluation, :additional_information]
+  GOVSPEAK_FIELDS = []
 
   belongs_to :assigned_to, class_name: "User"
 

--- a/app/models/licence_edition.rb
+++ b/app/models/licence_edition.rb
@@ -8,6 +8,8 @@ class LicenceEdition < Edition
   field :will_continue_on, :type => String
   field :continuation_link, :type => String
 
+  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:licence_overview]
+
   validates :licence_identifier, :presence => true
   validate :licence_identifier_unique
   validates_format_of :continuation_link, :with => URI::regexp(%w(http https)), :allow_blank => true

--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -10,6 +10,8 @@ class LocalTransactionEdition < Edition
   field :introduction,      type: String
   field :more_information,  type: String
 
+  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:introduction, :more_information]
+
   @fields_to_clone = [
     :lgsl_code, :introduction, :more_information,
     :minutes_to_complete, :expectation_ids

--- a/app/models/place_edition.rb
+++ b/app/models/place_edition.rb
@@ -8,6 +8,8 @@ class PlaceEdition < Edition
   field :more_information,  type: String
   field :place_type,        type: String
 
+  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:introduction, :more_information]
+
   @fields_to_clone = [:introduction, :more_information, :place_type,
                       :expectation_ids]
 

--- a/app/models/transaction_edition.rb
+++ b/app/models/transaction_edition.rb
@@ -11,6 +11,8 @@ class TransactionEdition < Edition
   field :more_information,  type: String
   field :alternate_methods, type: String
 
+  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:introduction, :more_information, :alternate_methods]
+
   @fields_to_clone = [:introduction, :will_continue_on, :link,
                       :more_information, :alternate_methods,
                       :minutes_to_complete, :uses_government_gateway,

--- a/app/models/video_edition.rb
+++ b/app/models/video_edition.rb
@@ -5,6 +5,8 @@ class VideoEdition < Edition
   field :video_summary, type: String
   field :body,          type: String
 
+  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body]
+
   @fields_to_clone = [:video_url, :video_summary, :body]
 
   def has_video?


### PR DESCRIPTION
This enables the content_api to govspeak them appropriately.
