### PR TITLE
Remove Plek.current.environment from fact check emails

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,5 +1,5 @@
-require "plek"
 require "workflow"
+require "fact_check_address"
 
 class Edition
   include Mongoid::Document
@@ -110,7 +110,7 @@ class Edition
   end
 
   def fact_check_email_address
-    "factcheck+#{Plek.current.environment}-#{id}@alphagov.co.uk"
+    FactCheckAddress.new.for_edition(self)
   end
 
   def get_next_version_number

--- a/lib/fact_check_address.rb
+++ b/lib/fact_check_address.rb
@@ -1,14 +1,27 @@
 require "plek"
 
 class FactCheckAddress
-  PREFIX = "factcheck+#{Plek.current.environment}-"
   DOMAIN = "alphagov.co.uk"
 
   def for_edition(edition)
-    "#{PREFIX}#{edition.id}@#{DOMAIN}"
+    "#{prefix}#{edition.id}@#{DOMAIN}"
   end
 
   def regexp
-    /#{PREFIX}(.+?)@#{DOMAIN}/
+    /#{prefix}(.+?)@#{DOMAIN}/
+  end
+
+  private
+  def prefix
+    "factcheck+#{environment}-"
+  end
+
+  # Fact check email addresses are environment dependent. This is
+  # a bad thing, but changing it would be very disruptive. Since
+  # Plek no longer gives us access to the environment we have to rely
+  # on the fact that the environment is included in the public domain
+  # name for an app.
+  def environment
+    Plek.current.find('publisher').split('.')[1]
   end
 end

--- a/lib/fact_check_address.rb
+++ b/lib/fact_check_address.rb
@@ -7,11 +7,15 @@ class FactCheckAddress
     "#{prefix}#{edition.id}@#{DOMAIN}"
   end
 
+  def valid_address?(address)
+    regexp.match(address)
+  end
+
+  private
   def regexp
     /#{prefix}(.+?)@#{DOMAIN}/
   end
 
-  private
   def prefix
     "factcheck+#{environment}-"
   end

--- a/lib/fact_check_address.rb
+++ b/lib/fact_check_address.rb
@@ -11,9 +11,9 @@ class FactCheckAddress
     regexp.match(address)
   end
 
-  def edition_from_address(address)
+  def edition_id_from_address(address)
     match = valid_address?(address)
-    match && match[0]
+    match && match[1]
   end
 
   private

--- a/lib/fact_check_address.rb
+++ b/lib/fact_check_address.rb
@@ -1,0 +1,14 @@
+require "plek"
+
+class FactCheckAddress
+  PREFIX = "factcheck+#{Plek.current.environment}-"
+  DOMAIN = "alphagov.co.uk"
+
+  def for_edition(edition)
+    "#{PREFIX}#{edition.id}@#{DOMAIN}"
+  end
+
+  def regexp
+    /#{PREFIX}(.+?)@#{DOMAIN}/
+  end
+end

--- a/lib/fact_check_address.rb
+++ b/lib/fact_check_address.rb
@@ -18,7 +18,7 @@ class FactCheckAddress
 
   private
   def regexp
-    /#{prefix}(.+?)@#{DOMAIN}/
+    /#{Regexp.escape(prefix)}(.+?)@#{DOMAIN}/
   end
 
   def prefix

--- a/lib/fact_check_address.rb
+++ b/lib/fact_check_address.rb
@@ -11,6 +11,11 @@ class FactCheckAddress
     regexp.match(address)
   end
 
+  def edition_from_address(address)
+    match = valid_address?(address)
+    match && match[0]
+  end
+
   private
   def regexp
     /#{prefix}(.+?)@#{DOMAIN}/

--- a/test/models/fact_check_address_test.rb
+++ b/test/models/fact_check_address_test.rb
@@ -1,8 +1,16 @@
 require "test_helper"
+require "fact_check_address"
 
 class FactCheckAddressTest < ActiveSupport::TestCase
-  test "provides a regexp that matches the addresses it produces" do
-    address = FactCheckAddress.new.for_edition(Edition.new)
-    assert address.match(FactCheckAddress.new.regexp)
+  test "can tell if an address is valid" do
+    service = FactCheckAddress.new
+    address = service.for_edition(Edition.new)
+    assert service.valid_address?(address), "Address should be valid but isn't"
+  end
+
+  test "can tell if an address is invalid" do
+    service = FactCheckAddress.new
+    address = "factcheck+staging-abde@alphagov.co.uk"
+    refute service.valid_address?(address), "Address should be invalid but isn't"
   end
 end

--- a/test/models/fact_check_address_test.rb
+++ b/test/models/fact_check_address_test.rb
@@ -13,4 +13,16 @@ class FactCheckAddressTest < ActiveSupport::TestCase
     address = "factcheck+staging-abde@alphagov.co.uk"
     refute service.valid_address?(address), "Address should be invalid but isn't"
   end
+
+  test "can extract edition ID from an address" do
+    service = FactCheckAddress.new
+    address = "factcheck+test-abde@alphagov.co.uk"
+    assert_equal "abde", service.edition_id_from_address(address)
+  end
+
+  test "can generate an address from an edition" do
+    service = FactCheckAddress.new
+    e = Edition.new
+    assert_match /#{e.id}/, service.for_edition(e)
+  end
 end

--- a/test/models/fact_check_address_test.rb
+++ b/test/models/fact_check_address_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class FactCheckAddressTest < ActiveSupport::TestCase
+  test "provides a regexp that matches the addresses it produces" do
+    address = FactCheckAddress.new.for_edition(Edition.new)
+    assert address.match(FactCheckAddress.new.regexp)
+  end
+end


### PR DESCRIPTION
Extracts FactCheckAddress as its own concept and calls that from Edition. This is to begin to centralise knowledge of those addresses and allows us to remove some duplicate code from publisher. These changes are backwards compatible.

This way of getting the environment is a hack. There's a cleaner way to do it, perhaps by setting the environment or address format on application initialisation. That would involve further reaching changes and the focus right now is on being able to upgrade Plek so I'm using it for a subsequent round of work.
