### PR TITLE
Tag tag_id's are unique within tag_type

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -12,7 +12,7 @@ class Tag
 
   GOVSPEAK_FIELDS = []
 
-  index :tag_id, unique: true
+  index [ [:tag_id, Mongo::ASCENDING], [:tag_type, Mongo::ASCENDING] ], unique: true
   index :tag_type
 
   validates_presence_of :tag_id, :title, :tag_type


### PR DESCRIPTION
There will be a migration in Panopticon to remove the old index and
add the new one (currently on a branch): https://github.com/alphagov/panopticon/commit/03e96ff8c531b8c7e85afa04c51e06963d972d88

This will let us have eg a section tag "business" and a keyword tag "business".
