### PR TITLE
Mock out environment in fact check email test.

### DIFF
--- a/test/models/fact_check_address_test.rb
+++ b/test/models/fact_check_address_test.rb
@@ -2,6 +2,14 @@ require "test_helper"
 require "fact_check_address"
 
 class FactCheckAddressTest < ActiveSupport::TestCase
+
+  setup do
+    dummy_plek = mock do
+      stubs(:find).with("publisher").returns("publisher.wibble.alphagov.co.uk")
+    end
+    Plek.stubs(:current).returns(dummy_plek)
+  end
+
   test "can tell if an address is valid" do
     service = FactCheckAddress.new
     address = service.for_edition(Edition.new)
@@ -10,13 +18,13 @@ class FactCheckAddressTest < ActiveSupport::TestCase
 
   test "can tell if an address is invalid" do
     service = FactCheckAddress.new
-    address = "factcheck+staging-abde@alphagov.co.uk"
+    address = "factcheck+notwibble-abde@alphagov.co.uk"
     refute service.valid_address?(address), "Address should be invalid but isn't"
   end
 
   test "can extract edition ID from an address" do
     service = FactCheckAddress.new
-    address = "factcheck+dev-abde@alphagov.co.uk"
+    address = "factcheck+wibble-abde@alphagov.co.uk"
     assert_equal "abde", service.edition_id_from_address(address)
   end
 


### PR DESCRIPTION
The tests would previously break if run with the wrong value of the `GOVUK_APP_DOMAIN` environment variable.
