### PR TITLE
Publish travel advice edition

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -21,10 +21,14 @@ class TravelAdviceEdition
   validates_presence_of :country_slug
   validate :state_for_slug_unique
   validates :version_number, :presence => true, :uniqueness => { :scope => :country_slug }
+  validate :state_if_modified
   validates_with SafeHtml
 
   scope :published, where(:state => "published")
 
+  class << self; attr_accessor :fields_to_clone end
+  @fields_to_clone = [:title, :country_slug, :overview]
+  
   state_machine initial: :draft do
 
     before_transition :draft => :published do |edition, transition|
@@ -43,7 +47,10 @@ class TravelAdviceEdition
   end
 
   def build_clone
-    new_edition = self.class.new(:country_slug => self.country_slug)
+    new_edition = self.class.new
+    self.class.fields_to_clone.each do |attr|
+      new_edition[attr] = self.read_attribute(attr)
+    end
     new_edition.parts = self.parts.map(&:dup)
     new_edition
   end
@@ -68,4 +75,11 @@ class TravelAdviceEdition
       end
     end
   end
+
+  def state_if_modified 
+    unless self.draft? or self.new_record? or self.changed == ['state']
+      errors.add(:state, "must be draft to modify")
+    end
+  end
+
 end


### PR DESCRIPTION
Adds before transition to archive travel advice editions for the same country and validates that changes cannot be made to published or archived travel advice editions.
