### PR TITLE
Add alert_status array to travel advice edition

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -13,6 +13,7 @@ class TravelAdviceEdition
   field :version_number,       type: Integer
   field :state,                type: String,    default: "draft"
   field :alert_status,         type: Array,     default: [ ]
+  field :summary,              type: String
 
   embeds_many :actions
 

--- a/test/models/travel_advice_edition_test.rb
+++ b/test/models/travel_advice_edition_test.rb
@@ -8,6 +8,7 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
     ed.overview = "This gives travel advice for Aruba"
     ed.country_slug = 'aruba'
     ed.alert_status = [ 'avoid_all_but_essential_travel_to_parts', 'avoid_all_travel_to_parts' ]
+    ed.summary = "This is the summary of stuff going on in Aruba"
     ed.version_number = 4
     ed.parts.build(:title => "Part One", :slug => "one")
     ed.safely.save!
@@ -17,6 +18,7 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
     assert_equal "This gives travel advice for Aruba", ed.overview
     assert_equal 'aruba', ed.country_slug
     assert_equal [ 'avoid_all_but_essential_travel_to_parts', 'avoid_all_travel_to_parts' ], ed.alert_status
+    assert_equal "This is the summary of stuff going on in Aruba", ed.summary
     assert_equal 4, ed.version_number
     assert_equal "Part One", ed.parts.first.title
   end


### PR DESCRIPTION
The alert status can contain any of a set of predefined values.
