### PR TITLE
Fix state validation on TravelAdviceEdition

### DIFF
--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -176,4 +176,19 @@ FactoryGirl.define do
     sequence(:country_slug) {|n| "test-country-#{n}" }
     sequence(:title) {|n| "Test Country #{n}" }
   end
+
+  # These factories only work when used with FactoryGirl.create
+  factory :draft_travel_advice_edition, :parent => :travel_advice_edition do
+  end
+  factory :published_travel_advice_edition, :parent => :travel_advice_edition do
+    after :create do |tae|
+      tae.publish!
+    end
+  end
+  factory :archived_travel_advice_edition, :parent => :travel_advice_edition do
+    after :create do |tae|
+      tae.state = 'archived'
+      tae.save!
+    end
+  end
 end


### PR DESCRIPTION
Now prevents editing non-draft editions.  Allows 'save & publish'.

A side-effect of this is that it's no longer possible to directly create a published or archived edition, you have to create a draft first, then publish it etc.  I've added some factories to make this process easier in tests.
