### PR TITLE
Travel advice edition bugfix

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -64,9 +64,11 @@ class TravelAdviceEdition
   end
 
   def indexable_content
-    parts.map do |part|
-      [part.title, Govspeak::Document.new(part.body).to_text]
-    end.flatten.join(" ").strip
+    strings = [Govspeak::Document.new(self.summary).to_text]
+    parts.each do |part|
+      strings << part.title << Govspeak::Document.new(part.body).to_text
+    end
+    strings.join(" ").strip
   end
 
   def build_clone

--- a/test/models/travel_advice_edition_test.rb
+++ b/test/models/travel_advice_edition_test.rb
@@ -245,15 +245,17 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
       @edition = FactoryGirl.build(:travel_advice_edition)
     end
 
-    should "return all part titles and bodies" do
-      @edition.parts << Part.new(:title => "Summary", :body => "A summary of stuff")
+    should "return summary and all part titles and bodies" do
+      @edition.summary = "The Summary"
+      @edition.parts << Part.new(:title => "Part One", :body => "Some text")
       @edition.parts << Part.new(:title => "More info", :body => "Some more information")
-      assert_equal "Summary A summary of stuff More info Some more information", @edition.indexable_content
+      assert_equal "The Summary Part One Some text More info Some more information", @edition.indexable_content
     end
 
     should "convert govspeak to plain text" do
-      @edition.parts << Part.new(:title => "Summary", :body => "A summary of stuff\n------")
-      assert_equal "Summary A summary of stuff", @edition.indexable_content
+      @edition.summary = "## The Summary"
+      @edition.parts << Part.new(:title => "Part One", :body => "* Some text")
+      assert_equal "The Summary Part One Some text", @edition.indexable_content
     end
   end
 


### PR DESCRIPTION
Fixes the following:
- Clone summary and alert_status when building new version
- Include summary in indexable_content
