### PR TITLE
Add a method that returns related items in order

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -161,6 +161,12 @@ class Artefact
     end
   end
 
+  # Pass in the desired scope, eg self.related_artefacts.live,
+  # get back the items in the order they were set in, rather than natural order
+  def ordered_related_artefacts(scope_or_array = self.related_artefacts)
+    scope_or_array.sort_by { |artefact| related_artefact_ids.index(artefact.id) }
+  end
+
   def any_editions_published?
     Edition.where(panopticon_id: self.id, state: 'published').any?
   end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -54,7 +54,7 @@ class ArtefactTest < ActiveSupport::TestCase
     assert_equal "other", a.kind
   end
 
-  test "should store related artefacts in order" do
+  test "should store and return related artefacts in order" do
     a = Artefact.create!(slug: "a", name: "a", kind: "place", need_id: 1, owning_app: "x")
     b = Artefact.create!(slug: "b", name: "b", kind: "place", need_id: 2, owning_app: "x")
     c = Artefact.create!(slug: "c", name: "c", kind: "place", need_id: 3, owning_app: "x")
@@ -63,7 +63,32 @@ class ArtefactTest < ActiveSupport::TestCase
     a.save!
     a.reload
 
-    assert_equal [b, c], a.related_artefacts
+    assert_equal [b, c], a.ordered_related_artefacts
+  end
+
+  test "should store and return related artefacts in order, even when not in natural order" do
+    a = Artefact.create!(slug: "a", name: "a", kind: "place", need_id: 1, owning_app: "x")
+    b = Artefact.create!(slug: "b", name: "b", kind: "place", need_id: 2, owning_app: "x")
+    c = Artefact.create!(slug: "c", name: "c", kind: "place", need_id: 3, owning_app: "x")
+
+    a.related_artefacts = [c, b]
+    a.save!
+    a.reload
+
+    assert_equal [c, b], a.ordered_related_artefacts
+  end
+
+  test "should store and return related artefacts in order, with a scope" do
+    a = Artefact.create!(slug: "a", name: "a", kind: "place", need_id: 1, owning_app: "x")
+    b = Artefact.create!(state: "live", slug: "b", name: "b", kind: "place", need_id: 2, owning_app: "x")
+    c = Artefact.create!(slug: "c", name: "c", kind: "place", need_id: 3, owning_app: "x")
+    d = Artefact.create!(state: "live", slug: "d", name: "d", kind: "place", need_id: 3, owning_app: "x")
+
+    a.related_artefacts = [d, c, b]
+    a.save!
+    a.reload
+
+    assert_equal [d, b], a.ordered_related_artefacts(a.related_artefacts.where(state: "live"))
   end
 
   test "published_related_artefacts should return all non-publisher artefacts, but only published publisher artefacts" do


### PR DESCRIPTION
Mongoid will preserve the order of related_artefact_ids. It does not respect
that ordering when using the relation (related_artefacts), and instead returns
them in natural order. The order of related_artefacts is semantically important
to us.
