### PR TITLE
Remove "relatedness done" flag

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -36,7 +36,6 @@ class Artefact
   field "active",               type: Boolean, default: false
   field "need_id",              type: String
   field "fact_checkers",        type: String
-  field "relatedness_done",     type: Boolean, default: false
   field "publication_id",       type: String
   field "description",          type: String
   field "state",                type: String,  default: "draft"

--- a/test/models/artefact_action_test.rb
+++ b/test/models/artefact_action_test.rb
@@ -20,7 +20,6 @@ class ArtefactActionTest < ActiveSupport::TestCase
   DEFAULTS = {
     "business_proposition" => false,
     "active" => false,
-    "relatedness_done" => false,
     "tag_ids" => [],
     "state" => "draft",
     "related_artefact_ids" => [],


### PR DESCRIPTION
This was used as a temporary mechanism for checking relatedness leading up to
the launch of GOV.UK, and is no longer used.
