### PR TITLE
Add pantopticon artefact enhancements to artefact model

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -112,6 +112,10 @@ class Artefact
     where(slug: s).first
   end
 
+  def self.relatable_items
+    self.in_alphabetical_order.where(:kind.nin => ["completed_transaction"], :state.nin => ["archived"])
+  end
+
   # The old-style section string identifier, of the form 'Crime:Prisons'
   def section
     return '' unless self.primary_section

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -381,4 +381,12 @@ class ArtefactTest < ActiveSupport::TestCase
     refute published_artefact.archived?
     assert archived_artefact.archived?
   end
+
+  should "have a related_items method which discards artefacts that are archived or completion transactions" do
+    generic = FactoryGirl.create(:artefact, slug: "generic")
+    archived = FactoryGirl.create(:artefact, :slug => "archived", :state => "archived")
+    completed = FactoryGirl.create(:artefact, slug: "completed-transaction", kind: "completed_transaction")
+
+    assert_equal [generic], Artefact.relatable_items
+  end
 end


### PR DESCRIPTION
These methods were added (by meta programming) to the Artefact model in Panopticon.

These same methods are needed elsewhere (Travel Advice Publisher) so pull them out from Panopticon and keep them with the model.
