### PR TITLE
Convert smart quotes to standard quotes in govspeak fields

### DIFF
--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -1,4 +1,5 @@
 require "safe_html"
+require 'govspeak_smart_quotes_fixer'
 
 class Part
   include Mongoid::Document
@@ -13,7 +14,9 @@ class Part
   field :slug,       type: String
   field :created_at, type: DateTime, default: lambda { Time.zone.now }
 
-  GOVSPEAK_FIELDS = []
+  GOVSPEAK_FIELDS = [:body]
+
+  include GovspeakSmartQuotesFixer
 
   validates_presence_of :title
   validates_presence_of :slug

--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -1,6 +1,7 @@
 require 'parted'
 require 'state_machine'
 require 'safe_html'
+require 'govspeak_smart_quotes_fixer'
 
 class TravelAdviceEdition
   include Mongoid::Document
@@ -33,6 +34,7 @@ class TravelAdviceEdition
     "avoid_all_travel_to_whole_country",
   ]
 
+  include GovspeakSmartQuotesFixer
   before_validation :populate_version_number, :on => :create
 
   validates_presence_of :country_slug, :title

--- a/app/traits/govspeak_smart_quotes_fixer.rb
+++ b/app/traits/govspeak_smart_quotes_fixer.rb
@@ -1,0 +1,19 @@
+# encoding: UTF-8
+
+module GovspeakSmartQuotesFixer
+  def self.included(model)
+    model.class_eval do
+      before_validation :fix_smart_quotes_in_govspeak
+    end
+  end
+
+  private
+
+  def fix_smart_quotes_in_govspeak
+    self.class::GOVSPEAK_FIELDS.each do |field|
+      if self.send(field) =~ /[“”]/
+        self.send(field).gsub!(/[“”]/, '"')
+      end
+    end
+  end
+end

--- a/test/models/travel_advice_edition_test.rb
+++ b/test/models/travel_advice_edition_test.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require "test_helper"
 
 class TravelAdviceEditionTest < ActiveSupport::TestCase
@@ -197,6 +199,36 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
         @ta.change_description = ""
         assert @ta.valid?
       end
+    end
+  end
+
+  context "fixing user input" do
+    setup do
+      @ed = FactoryGirl.build(:travel_advice_edition)
+    end
+
+    should "convert smart quotes in the change_description field" do
+      @ed.change_description = "Something changed on [GOV.UK](https://www.gov.uk/ “GOV.UK”)"
+      @ed.save!
+
+      @ed.reload
+      assert_equal 'Something changed on [GOV.UK](https://www.gov.uk/ "GOV.UK")', @ed.change_description
+    end
+
+    should "convert smart quotes in the summary field" do
+      @ed.summary = "This is a [link](https://www.gov.uk/ “link”)"
+      @ed.save!
+
+      @ed.reload
+      assert_equal 'This is a [link](https://www.gov.uk/ "link")', @ed.summary
+    end
+
+    should "convert smart quotes in part bodies" do
+      @ed.parts.build(:title => 'One', :slug => 'one', :body => "This is a [link](https://www.gov.uk/ “link”)")
+      @ed.save!
+
+      @ed.reload
+      assert_equal 'This is a [link](https://www.gov.uk/ "link")', @ed.parts.first.body
     end
   end
 


### PR DESCRIPTION
Fixes copy that's copy/pasted from Word et al. that breaks the markdown
in some cases (e.g. link titles)

At the moment this is implemented for TravelAdviceEdition (and Part).  This could be rolled out to all Editions.
