### PR TITLE
Sort parts by the order attribute

### DIFF
--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -14,8 +14,6 @@ class Part
   field :slug,       type: String
   field :created_at, type: DateTime, default: lambda { Time.zone.now }
 
-  default_scope asc(:order)
-
   GOVSPEAK_FIELDS = [:body]
 
   include GovspeakSmartQuotesFixer

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -587,17 +587,6 @@ class EditionTest < ActiveSupport::TestCase
     end
   end
 
-  test "parts are sorted by the order field" do
-    edition = GuideEdition.new(title: "One", slug: "one", panopticon_id: @artefact.id)
-    edition.parts.build title: "Biscuits", body:"Never gonna give you up", slug: "biscuits", order: 2
-    edition.parts.build title: "Cookies", body:"NYAN NYAN NYAN NYAN", slug: "cookies", order: 1
-    edition.save!
-    edition.reload
-
-    assert_equal "Cookies", edition.parts.first.title
-    assert_equal "Biscuits", edition.parts.last.title
-  end
-
   test "user should not be able to review an edition they requested review for" do
     user = User.create(name: "Mary")
 


### PR DESCRIPTION
Sort the list of parts by the value in the order attribute, so that changes to the order are persisted when the edit form is reloaded.

This fixes an issue with the order of parts not being reflected in the form of travel advice publisher.

There is a chance that this may break existing behaviour if there have been previous assumptions made around how parts are sorted. I'd appreciate a glance at this from @mnowster or @fatbusinessman to see if this might break the sorting of parts in Publisher or Content API.
