### PR TITLE
Fix validation of licence and business support ids

### DIFF
--- a/app/models/business_support_edition.rb
+++ b/app/models/business_support_edition.rb
@@ -43,7 +43,7 @@ class BusinessSupportEdition < Edition
   end
   
   def business_support_identifier_unique
-    if self.class.where(:business_support_identifier => business_support_identifier,
+    if self.class.without_state('archived').where(:business_support_identifier => business_support_identifier,
                         :panopticon_id.ne => panopticon_id).any?
       errors.add(:business_support_identifier, :taken)
     end

--- a/app/models/licence_edition.rb
+++ b/app/models/licence_edition.rb
@@ -27,7 +27,7 @@ class LicenceEdition < Edition
 
   private
   def licence_identifier_unique
-    if self.class.where(:licence_identifier => licence_identifier,
+    if self.class.without_state('archived').where(:licence_identifier => licence_identifier,
                         :panopticon_id.ne => panopticon_id).any?
       errors.add(:licence_identifier, :taken)
     end

--- a/test/models/business_support_edition_test.rb
+++ b/test/models/business_support_edition_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "../test_helper"
 
 class BusinessSupportEditionTest < ActiveSupport::TestCase
   def setup
@@ -51,15 +51,26 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
     assert ! support.valid?, "expected business support edition not to be valid"
   end
 
-  should "have a unique business support identifier" do
-    support = FactoryGirl.create(:business_support_edition, panopticon_id: @artefact.id,
-      business_support_identifier: "this-should-be-unique")
-    another_artefact = FactoryGirl.create(:artefact)
-    another_support = FactoryGirl.create(:business_support_edition, panopticon_id: another_artefact.id)
-    another_support.business_support_identifier = "this-should-be-unique"
-    assert !another_support.valid?, "business_support_identifier should be unique"
-    another_support.business_support_identifier = "this-is-different"
-    assert another_support.valid?, "business_support_identifier should be unique"
+  context "business support identifier uniqueness" do
+    setup do
+      @support = FactoryGirl.build(:business_support_edition, panopticon_id: @artefact.id)
+      @another_artefact = FactoryGirl.create(:artefact)
+    end
+    should "have a unique business support identifier" do
+      another_support = FactoryGirl.create(:business_support_edition, panopticon_id: @another_artefact.id,
+                                          :business_support_identifier => "this-should-be-unique")
+      @support.business_support_identifier = "this-should-be-unique"
+      assert !@support.valid?, "business_support_identifier should be unique"
+      @support.business_support_identifier = "this-is-different"
+      assert @support.valid?, "business_support_identifier should be unique"
+    end
+
+    should "not consider archived editions when evaluating uniqueness" do
+      another_support = FactoryGirl.create(:business_support_edition, panopticon_id: @another_artefact.id,
+                                           :business_support_identifier => "this-should-be-unique", :state => "archived")
+      @support.business_support_identifier = "this-should-be-unique"
+      assert @support.valid?, "business_support should be valid"
+    end
   end
   
   context "continuation_link validation" do 

--- a/test/models/licence_edition_test.rb
+++ b/test/models/licence_edition_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class LicenceEditionTest < ActiveSupport::TestCase
   def setup
@@ -32,11 +32,20 @@ class LicenceEditionTest < ActiveSupport::TestCase
       assert_equal false, @l.valid?, "expected licence edition not to be valid"
     end
 
-    should "require a unique licence identifier" do
-      artefact2 = FactoryGirl.create(:artefact)
-      FactoryGirl.create(:licence_edition, :licence_identifier => "wibble", panopticon_id: artefact2.id)
-      @l.licence_identifier = "wibble"
-      assert ! @l.valid?, "expected licence edition not to be valid"
+    context "licence identifier uniqueness" do
+      should "require a unique licence identifier" do
+        artefact2 = FactoryGirl.create(:artefact)
+        FactoryGirl.create(:licence_edition, :licence_identifier => "wibble", panopticon_id: artefact2.id)
+        @l.licence_identifier = "wibble"
+        assert ! @l.valid?, "expected licence edition not to be valid"
+      end
+
+      should "not consider archived editions when evaluating uniqueness" do
+        artefact2 = FactoryGirl.create(:artefact)
+        FactoryGirl.create(:licence_edition, :licence_identifier => "wibble", panopticon_id: artefact2.id, :state => "archived")
+        @l.licence_identifier = "wibble"
+        assert @l.valid?, "expected licence edition to be valid"
+      end
     end
 
     should "not require a unique licence identifier for different versions of the same licence edition" do


### PR DESCRIPTION
This relaxes the uniqueness validation so that it doesn't consider
archived editions when evaluating uniqueness.  This will make it
possible to fix editions where the identifiers have been entered the
wrong way round (e.g. https://www.pivotaltracker.com/story/show/48887667).
