### PR TITLE
Add unique index to Artefact slug field

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -43,6 +43,8 @@ class Artefact
   field "language",             type: String,  default: "en"
   field "need_extended_font",   type: Boolean, default: false
 
+  index "slug", :unique => true
+
   scope :not_archived, where(:state.nin => ["archived"])
 
   GOVSPEAK_FIELDS = []


### PR DESCRIPTION
This has a couple of benefits:
1. It will catch any uniqueness violations that validates_uniqueness_of
   misses
2. Small performance benefit:

Times for requesting 5 different artefacts 10 times over in content_api on my dev VM:

```
          Cold  Warm1 Warm2 Warm3
No Index  3.743 3.697 3.613 3.582
Index     3.082 2.817 3.154 3.087
```

The cold column is with a freshly started instance of both mongo and content_api.
