### PR TITLE
Modify the SafeHtml test to check the models directory

### DIFF
--- a/test/validators/safe_html_validator_test.rb
+++ b/test/validators/safe_html_validator_test.rb
@@ -71,9 +71,12 @@ class SafeHtmlTest < ActiveSupport::TestCase
     end
 
     should "all models should use this validator" do
-      classes = ObjectSpace.each_object(::Module).select do |klass|
-        klass < Mongoid::Document
-      end
+      models_dir = File.expand_path("../../app/models/*", File.dirname(__FILE__))
+
+      classes = Dir[models_dir].map do |file|
+        klass = File.basename(file, ".rb").camelize.constantize
+        klass.included_modules.include?(Mongoid::Document) ? klass : nil
+      end.compact
 
       classes.each do |klass|
         assert_includes klass.validators.map(&:class), SafeHtml, "#{klass} must be validated with SafeHtml"


### PR DESCRIPTION
This fixes two things:
- The outcome of this test is no longer dependent on which models have been loaded over the duration of the test suite.
- It is correctly scoped to checking just the models in `app/models`, so that Mock objects do not have the overhead of using SafeHtml and can be tested in greater isolation.
