### PR TITLE
Relax uniqueness constraint on local_directgov_id

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -18,7 +18,7 @@ class LocalAuthority
 
   GOVSPEAK_FIELDS = []
 
-  validates_uniqueness_of :snac, :local_directgov_id
+  validates_uniqueness_of :snac
   validates_presence_of   :snac, :local_directgov_id, :name, :tier
   validates_with SafeHtml
 


### PR DESCRIPTION
We're not actually using this field, and the id's sometimes swap round
upstream, which causes errors on import.  We can relax this, and rely on
the uniqueness being constrained in the upstream data.
