### PR TITLE
add nested attributes for external_links

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -95,7 +95,10 @@ class Artefact
 
   has_and_belongs_to_many :related_artefacts, class_name: "Artefact"
   embeds_many :actions, class_name: "ArtefactAction", order: :created_at
+
   embeds_many :external_links, class_name: "ArtefactExternalLink"
+  accepts_nested_attributes_for :external_links, :allow_destroy => true,
+    reject_if: proc { |attrs| attrs["title"].blank? && attrs["url"].blank?  }
 
   before_validation :normalise, on: :create
   before_create :record_create_action

--- a/app/models/artefact_external_link.rb
+++ b/app/models/artefact_external_link.rb
@@ -1,6 +1,5 @@
 class ArtefactExternalLink
   include Mongoid::Document
-  include Mongoid::Timestamps::Created
 
   field "title", type: String
   field "url", type: String


### PR DESCRIPTION
Also removed the Mongo Timestamps. We don't need them for external links.
