### PR TITLE
Ignore node attrs containing destroy

### DIFF
--- a/app/models/simple_smart_answer_edition.rb
+++ b/app/models/simple_smart_answer_edition.rb
@@ -42,21 +42,25 @@ class SimpleSmartAnswerEdition < Edition
       nodes_attrs.each do |index, node_attrs|
         if node_id = node_attrs['id']
           node = nodes.find(node_id)
-          if node_attrs["_destroy"] == '1'
+          if destroy_in_attrs?(node_attrs)
             node.destroy
           else
             node.update_attributes(node_attrs)
           end
         else
-          nodes << Node.new(node_attrs)
+          nodes << Node.new(node_attrs) unless destroy_in_attrs?(node_attrs)
         end
       end
     end
-    
+
     original_update_attributes(attributes)
   end
 
   def initial_node
     self.nodes.first
+  end
+
+  def destroy_in_attrs?(attrs)
+    attrs['_destroy'] == '1'
   end
 end

--- a/test/models/simple_smart_answer_edition_test.rb
+++ b/test/models/simple_smart_answer_edition_test.rb
@@ -152,5 +152,18 @@ class SimpleSmartAnswerEditionTest < ActiveSupport::TestCase
       assert_equal "outcome1", @edition.nodes.second.options.first.next_node
       assert_equal "Outcome 1", @edition.nodes.third.title
     end
+    
+    should "ignore new nodes if they are to be destroyed" do
+      @edition.update_attributes({
+        :nodes_attributes => {
+          "0" => { "id" => @edition.nodes.first.id, "title" => "Question the first" }, 
+          "1" => { "title" => "", "slug" => "", "kind" => "outcome", "_destroy" => "1" }
+        }
+      })
+      @edition.reload
+
+      assert_equal "Question the first", @edition.nodes.first.title
+      assert_equal 2, @edition.nodes.size
+    end
   end
 end


### PR DESCRIPTION
Part of https://www.pivotaltracker.com/story/show/50642999
Bugfix to [this observation](https://github.com/alphagov/publisher/pull/115#issuecomment-20972032) by @alext 
Does not attempt to create nodes from attrs which contain a positive destroy value.
