### PR TITLE
Fix TravelAdvice review date bug

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -58,11 +58,12 @@ class TravelAdviceEdition
       if edition.minor_update
         previous = edition.previous_version
         edition.published_at = previous.published_at
+        edition.reviewed_at = previous.reviewed_at
         edition.change_description = previous.change_description
       else
         edition.published_at = Time.zone.now.utc
+        edition.reviewed_at = edition.published_at
       end
-      edition.reviewed_at = edition.published_at
       edition.class.where(country_slug: edition.country_slug, state: 'published').each do |ed|
         ed.archive
       end

--- a/test/models/travel_advice_edition_test.rb
+++ b/test/models/travel_advice_edition_test.rb
@@ -369,6 +369,9 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
     setup do
       @published = FactoryGirl.create(:published_travel_advice_edition, :country_slug => 'aruba',
                                       :published_at => 3.days.ago, :change_description => 'Stuff changed')
+      @published.reviewed_at = 2.days.ago
+      @published.save!
+
       Timecop.freeze(1.days.ago) do
         # this is done to make sure there's a significant difference in time
         # between creating the edition and it being published
@@ -382,10 +385,10 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
       assert_equal @ed.published_at, @ed.reviewed_at
     end
 
-    should "be updated when a minor update is published" do
+    should "be set to the previous version's reviewed_at when a minor update is published" do
       @ed.minor_update = true
       @ed.publish!
-      assert_equal @ed.published_at, @ed.reviewed_at
+      assert_equal @published.reviewed_at, @ed.reviewed_at
     end
 
     should "be able to be updated without affecting other dates" do


### PR DESCRIPTION
On publishing a minor update, the review date of the previous edition should be preserved.
