### PR TITLE
Bump the Mongoid dependency to 2.5.x onwards.

### DIFF
--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gds-sso",          ">= 3.0.0", "< 4.0.0"
   gem.add_dependency "govspeak",         ">= 1.0.1", "< 2.0.0"
-  gem.add_dependency "mongoid",          "~> 2.4.10"
+  # Mongoid 2.5.0 supports the newer 1.7.x and 1.8.x Mongo drivers
+  gem.add_dependency "mongoid",          "~> 2.5"
   gem.add_dependency "plek"
   gem.add_dependency "state_machine"
 


### PR DESCRIPTION
Our current Mongo drivers are 15 months out of date, which may be showing up a bug with the connection pool handling. Version 2.5.0 and onwards of Mongoid support the newer drivers. Versions 2.6.x and 2.7.x claim to be backwards-compatible, so we don't want to stop apps using those.
