### PR TITLE
Fix indexing for the `relatable_items` method.

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -45,7 +45,13 @@ class Artefact
 
   index "slug", :unique => true
 
-  index [[:state, Mongo::ASCENDING], [:kind, Mongo::ASCENDING], [:name, Mongo::ASCENDING]]
+  # This index allows the `relatable_artefacts` method to use an index-covered
+  # query, so it doesn't have to load each of the artefacts.
+  index [[:name, Mongo::ASCENDING],
+         [:state, Mongo::ASCENDING],
+         [:kind, Mongo::ASCENDING],
+         [:_type, Mongo::ASCENDING],
+         [:_id, Mongo::ASCENDING]]
 
   scope :not_archived, where(:state.nin => ["archived"])
 
@@ -127,9 +133,6 @@ class Artefact
   end
 
   def self.relatable_items
-    # Using inequality, rather than non-inclusion, because a non-inclusion
-    # query would prevent us using the index on :state, :kind and :name
-    #
     # Only retrieving the name field, because that's all we use in Panopticon's
     # helper method (the only place we use this), and it means the index can
     # cover the query entirely


### PR DESCRIPTION
Ok, there's a bunch of things I misunderstood here:
- Inequality checking isn't any better for the index than "not in" exclusion. There's nothing stopping us switching back to the `$nin` form for the `kind` and `state` filters, should we need to exclude multiple values.
- The name should always have gone first in the query, because we're sorting on it. Oops.
- Mongo indexes don't include the `_id` field unless you specifically include it. I had assumed the index would implicitly include the document's ID, but we need to add it explicitly for a covered query.
- Because `Artefact` has other types inheriting from it, Mongoid will automatically ask for a `_type` field in any artefact query and use that to determine which class to instantiate, so we need to include that in the index to cover the query. I didn't spot that.
