### PR TITLE
Allow sector tags to be stored for an Artefact

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -18,7 +18,7 @@ class Artefact
 
   include Taggable
   stores_tags_for :sections, :writing_teams, :propositions,
-                  :keywords, :legacy_sources, :sectors
+                  :keywords, :legacy_sources, :industry_sectors
   has_primary_tag_for :section
 
   # NOTE: these fields are deprecated, and soon to be replaced with a


### PR DESCRIPTION
Add 'sectors' to the list of tags which can be added to an Artefact.

A sector tag is a section-like term to group GOV.UK content (largely detailed guides) by the industry sector which it applies to. Like sections, sectors can be nested in a hierarchy.
