### PR TITLE
Don't change the slug during validation

### DIFF
--- a/app/validators/slug_validator.rb
+++ b/app/validators/slug_validator.rb
@@ -15,7 +15,7 @@ class SlugValidator < ActiveModel::EachValidator
     elsif value.to_s =~ /\Agovernment\/(.+)/ and prefixed_inside_government_format_names.include?(record.kind)
       parts = $1.split('/')
     else
-      parts = [value]
+      parts = [value.clone]
     end
 
     if record.respond_to?(:kind)

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -371,6 +371,13 @@ class ArtefactTest < ActiveSupport::TestCase
     end
   end
 
+  should "not remove double dashes in a Detailed Guide slug" do
+    a = FactoryGirl.create(:artefact, slug: "duplicate-slug--1", kind: "detailed_guide")
+    a.reload
+
+    assert_equal "duplicate-slug--1", a.slug
+  end
+
   context "artefact language" do
     should "return english by default" do
       a = FactoryGirl.create(:artefact)


### PR DESCRIPTION
As the slug for an artefact was being passed as a reference into the slug validator, slugs for detailed guides were being changed during validation when we replaced any double dashes with a single dash.

This makes sure that, when we pass the slug directly into the validator, we clone it so that any changes don't affect the value in the Artefact.
