### PR TITLE
Use correct index syntax for mongoid 2.x on business support facets

### DIFF
--- a/app/models/business_support/business_size.rb
+++ b/app/models/business_support/business_size.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug
+    index :slug, unique: true
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/business_type.rb
+++ b/app/models/business_support/business_type.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug
+    index :slug, unique: true
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/location.rb
+++ b/app/models/business_support/location.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug
+    index :slug, unique: true
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/purpose.rb
+++ b/app/models/business_support/purpose.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug
+    index :slug, unique: true
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/sector.rb
+++ b/app/models/business_support/sector.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug
+    index :slug, unique: true
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/stage.rb
+++ b/app/models/business_support/stage.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug
+    index :slug, unique: true
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/support_type.rb
+++ b/app/models/business_support/support_type.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug
+    index :slug, unique: true
 
     validates_presence_of :name
     validates_uniqueness_of :name


### PR DESCRIPTION
These facet classes were cloned from an application which ran mongoid 3.x.
The index definitions use a different syntax between mongoid 2 and 3 so fix this.

For reference here's the original commit on Imminence where the indexes were updated:
https://github.com/alphagov/imminence/commit/ae9b6ba261ced8eb2671b8df3b0ee93b3122f2ad#diff-c19b3a2bed3e63b1e2b66b5776f9d351L6
