### PR TITLE
Makes it compatible with gds-sso 7.0.0

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User
   field "email",               type: String
   field "permissions",         type: Array
   field "remotely_signed_out", type: Boolean, default: false
+  field "organisation_slug",   type: String
   
   GOVSPEAK_FIELDS = []
 
@@ -32,12 +33,6 @@ class User
   scope :alphabetized, order_by(name: :asc)
 
   validates_with SafeHtml
-
-  # GDS::SSO specifically looks for find_by_uid within warden
-  # when loading authentication user from session
-  def self.find_by_uid(uid)
-    where(uid: uid).first
-  end
 
   def to_s
     name || email || ""

--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "differ"
   gem.add_dependency "gds-api-adapters"
 
-  gem.add_dependency "gds-sso",          ">= 3.0.0", "< 4.0.0"
+  gem.add_dependency "gds-sso",          ">= 7.0.0", "< 10.0.0"
   gem.add_dependency "govspeak",         ">= 1.0.1", "< 2.0.0"
   # Mongoid 2.5.0 supports the newer 1.7.x and 1.8.x Mongo drivers
   gem.add_dependency "mongoid",          "~> 2.5"


### PR DESCRIPTION
we need this update to make sure apps that 
use govuk_content_models can update gds-sso
to 9.2.0 which contains a UX fix for remote logout:

http://git.io/llA6Qw
