### PR TITLE
Rename the tag type "industry_sector" to "specialist_sector"

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -18,7 +18,7 @@ class Artefact
 
   include Taggable
   stores_tags_for :sections, :writing_teams, :propositions,
-                  :keywords, :legacy_sources, :industry_sectors
+                  :keywords, :legacy_sources, :specialist_sectors
   has_primary_tag_for :section
 
   # NOTE: these fields are deprecated, and soon to be replaced with a


### PR DESCRIPTION
We've clarified our language a bit and what has previously been called "industry sectors" are now being called "specialist sectors". This pull request changes the list of tag types in the Artefact model to reflect this change. 

This is a breaking change, as existing methods for the industry_sector tags will no longer be defined. This should be released as a major version bump.
