### PR TITLE
Add an organisations tag type

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -18,7 +18,7 @@ class Artefact
 
   include Taggable
   stores_tags_for :sections, :writing_teams, :propositions,
-                  :keywords, :legacy_sources, :specialist_sectors
+                  :keywords, :legacy_sources, :specialist_sectors, :organisations
   has_primary_tag_for :section
 
   # NOTE: these fields are deprecated, and soon to be replaced with a


### PR DESCRIPTION
We would like to start tagging mainstream content with associated organisations. To do this, this adds a new tag type for an artefact called "organisations".
