### PR TITLE
Remove requires conflicting with Rails Engine load

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -1,4 +1,3 @@
-require "slug_validator"
 require "plek"
 require "traits/taggable"
 require "artefact_action"  # Require this when running outside Rails

--- a/app/models/curated_list.rb
+++ b/app/models/curated_list.rb
@@ -1,4 +1,3 @@
-require "slug_validator"
 require "traits/taggable"
 require "safe_html"
 

--- a/lib/govuk_content_models/require_all.rb
+++ b/lib/govuk_content_models/require_all.rb
@@ -3,13 +3,12 @@ require "active_model"
 require "mongoid"
 require "govuk_content_models"
 
-%w[ app/models app/validators app/repositories app/traits lib ].each do |path|
-  full_path = File.expand_path(
-    "#{File.dirname(__FILE__)}/../../#{path}", __FILE__)
+root_path = "#{File.dirname(__FILE__)}/../.."
+%w[ app/models app/validators app/traits lib ].each do |path|
+  full_path = File.expand_path("#{root_path}/#{path}")
   $LOAD_PATH.unshift full_path unless $LOAD_PATH.include?(full_path)
 end
 
-# Require everything under app
-Dir.glob("#{File.dirname(__FILE__)}/../../app/**/*.rb").each do |file|
-  require file
-end
+# Require validators first, then other files in app
+Dir.glob("#{root_path}/app/validators/*.rb").each {|f| require f }
+Dir.glob("#{root_path}/app/**/*.rb").each {|f| require f }


### PR DESCRIPTION
Rails engine eager_load! loads the slug_validator
anyways, so we should not try to load it again.

When the model artefact.rb requires slug_validator
and the Rails engine load doesn't yet know of it,
it tries loading it again. This was causing the
InstanceValidator to be redefined with a new
instance of Struct causing superclass mismatch
error.
