### PR TITLE
Add `editors_note` field to edition model

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -21,6 +21,7 @@ class Edition
   field :department,           type: String
   field :rejected_count,       type: Integer,  default: 0
   field :tags,                 type: String
+  field :editors_note,         type: String
 
   field :assignee,             type: String
   field :creator,              type: String

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -992,4 +992,32 @@ class EditionTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "Editors note" do
+    def set_note(edition, note)
+      edition.editors_note = note
+      edition.save
+      edition.reload
+    end
+
+    setup do
+      @edition = FactoryGirl.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
+      set_note(@edition, "This is an important note.")
+    end
+
+    should "be able to add an editors note to an edition" do
+      assert_equal "This is an important note.", @edition.editors_note
+    end
+
+    should "be able to update an existing editors note" do
+      set_note(@edition, "New note.")
+      assert_equal "New note.", @edition.editors_note
+    end
+
+    should "should not exist when creating new editions" do
+      Edition.subclasses.each do |klass|
+        refute klass.fields_to_clone.include?(:editors_note), "Editors note is cloned in a #{klass}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Content editors need to be able to add a note of importance to an edition (e.g. don't publish until xx/yy/zz date, publish after another edition is publised, etc).

The note added doesn't get passed on to future editions.
