### PR TITLE
Remove nil initialization of instance variable

### DIFF
--- a/app/traits/attachable.rb
+++ b/app/traits/attachable.rb
@@ -1,8 +1,6 @@
 module Attachable
   class ApiClientNotPresent < StandardError; end
 
-  @asset_api_client = nil
-
   def self.asset_api_client
     @asset_api_client
   end


### PR DESCRIPTION
For some reason this file is being loaded twice,
the second loading wipes out the setting of the
instance variable.

Removing the unnecessary initialization allows the
multiple loads.
