### PR TITLE
editors_note renamed more accurately to workflow_note

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -21,7 +21,7 @@ class Edition
   field :department,           type: String
   field :rejected_count,       type: Integer,  default: 0
   field :tags,                 type: String
-  field :editors_note,         type: String
+  field :workflow_note,        type: String
 
   field :assignee,             type: String
   field :creator,              type: String

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -984,9 +984,9 @@ class EditionTest < ActiveSupport::TestCase
     end
   end
 
-  context "Editors note" do
+  context "Workflow note" do
     def set_note(edition, note)
-      edition.editors_note = note
+      edition.workflow_note = note
       edition.save
       edition.reload
     end
@@ -996,18 +996,18 @@ class EditionTest < ActiveSupport::TestCase
       set_note(@edition, "This is an important note.")
     end
 
-    should "be able to add an editors note to an edition" do
-      assert_equal "This is an important note.", @edition.editors_note
+    should "be able to add a workflow note to an edition" do
+      assert_equal "This is an important note.", @edition.workflow_note
     end
 
-    should "be able to update an existing editors note" do
+    should "be able to update an existing workflow note" do
       set_note(@edition, "New note.")
-      assert_equal "New note.", @edition.editors_note
+      assert_equal "New note.", @edition.workflow_note
     end
 
     should "should not exist when creating new editions" do
       Edition.subclasses.each do |klass|
-        refute klass.fields_to_clone.include?(:editors_note), "Editors note is cloned in a #{klass}"
+        refute klass.fields_to_clone.include?(:workflow_note), "Workflow note is cloned in a #{klass}"
       end
     end
   end


### PR DESCRIPTION
The comment's intent is for users to describe cases where the ordinary workflow isn't to be taken.
