### PR TITLE
Add RenderedSpecialistDocument model

### DIFF
--- a/app/models/rendered_specialist_document.rb
+++ b/app/models/rendered_specialist_document.rb
@@ -1,0 +1,22 @@
+class RenderedSpecialistDocument
+  include Mongoid::Document
+
+  field :slug,          type: String
+  field :title,         type: String
+  field :summary,       type: String
+  field :body,          type: String
+  field :opened_date,   type: Date
+  field :closed_date,   type: Date
+  field :case_type,     type: String
+  field :case_state,    type: String
+  field :market_sector, type: String
+  field :outcome_type,  type: String
+  field :headers,       type: Array
+
+  index "slug", unique: true
+
+  GOVSPEAK_FIELDS = []
+
+  validates :slug, uniqueness: true
+  validates_with SafeHtml
+end

--- a/test/fixtures/specialist_document_fixtures.rb
+++ b/test/fixtures/specialist_document_fixtures.rb
@@ -1,0 +1,16 @@
+module SpecialistDocumentFixtures
+  def basic_specialist_document_fields
+    {
+      slug: 'cma-cases/merger-investigation-2014',
+      title: "Merger Investigation 2014",
+      summary: "This is the summary of stuff going on in the Merger Investigation 2014",
+      state: "published",
+      body: "A body",
+      opened_date: '2012-04-21',
+      document_id: 'a-document-id',
+      market_sector: 'oil-and-gas',
+      case_type: 'some-case-type',
+      case_state: 'open'
+    }
+  end
+end

--- a/test/models/rendered_specialist_document_test.rb
+++ b/test/models/rendered_specialist_document_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+require "fixtures/specialist_document_fixtures"
+
+class RenderedSpecialistDocumentTest < ActiveSupport::TestCase
+  include SpecialistDocumentFixtures
+
+  test "can assign all attributes" do
+    r = RenderedSpecialistDocument.new(basic_specialist_document_fields)
+    basic_specialist_document_fields.each do |k,v|
+      if (k =~ /date$/)
+        assert_equal Date.parse(v), r.send(k.to_sym)
+      else
+        assert_equal v, r.send(k.to_sym)
+      end
+    end
+  end
+
+  test "can persist" do
+    r = RenderedSpecialistDocument.new(basic_specialist_document_fields)
+    r.save!
+
+    assert_equal 1, RenderedSpecialistDocument.where(slug: r.slug).count
+  end
+
+  test "duplicate slugs disallowed" do
+    RenderedSpecialistDocument.create(slug: "my-slug")
+    second = RenderedSpecialistDocument.create(slug: "my-slug")
+
+    refute second.valid?
+    assert_equal 1, RenderedSpecialistDocument.count
+  end
+
+  test "has no govspeak fields" do
+    assert_equal [], RenderedSpecialistDocument::GOVSPEAK_FIELDS
+  end
+
+  test "can store headers hash" do
+    sample_headers = [
+      {
+        "text" => "Phase 1",
+        "level" => 2,
+        "id" => "phase-1",
+        "headers" => []
+      }
+    ]
+    sample_fields = basic_specialist_document_fields.merge(headers: sample_headers)
+    r = RenderedSpecialistDocument.create!(sample_fields)
+
+    found = RenderedSpecialistDocument.where(slug: r.slug).first
+    assert_equal sample_headers, found.headers
+  end
+end

--- a/test/models/specialist_document_edition_test.rb
+++ b/test/models/specialist_document_edition_test.rb
@@ -1,22 +1,10 @@
 # encoding: UTF-8
 
 require "test_helper"
+require "fixtures/specialist_document_fixtures"
 
 class SpecialistDocumentEditionTest < ActiveSupport::TestCase
-  def basic_edition_fields
-    {
-      slug: 'cma-cases/merger-investigation-2014',
-      title: "Merger Investigation 2014",
-      summary: "This is the summary of stuff going on in the Merger Investigation 2014",
-      state: "published",
-      body: "A body",
-      opened_date: '2012-04-21',
-      document_id: 'a-document-id',
-      market_sector: 'oil-and-gas',
-      case_type: 'some-case-type',
-      case_state: 'open'
-    }
-  end
+  include SpecialistDocumentFixtures
 
   setup do
     @original_asset_api_client = Attachable.asset_api_client
@@ -28,13 +16,13 @@ class SpecialistDocumentEditionTest < ActiveSupport::TestCase
   end
 
   should "have correct fields" do
-    edition = SpecialistDocumentEdition.new(basic_edition_fields)
+    edition = SpecialistDocumentEdition.new(basic_specialist_document_fields)
 
-    assert_equal basic_edition_fields[:title], edition.title
+    assert_equal basic_specialist_document_fields[:title], edition.title
   end
 
   should "be persistable" do
-    edition = SpecialistDocumentEdition.create!(basic_edition_fields)
+    edition = SpecialistDocumentEdition.create!(basic_specialist_document_fields)
 
     found = SpecialistDocumentEdition.where(slug: edition.slug).first
     assert_equal found.attributes, edition.attributes
@@ -56,7 +44,7 @@ class SpecialistDocumentEditionTest < ActiveSupport::TestCase
     should "persist attachment record when document saved" do
       Attachable.asset_api_client.stubs(:create_asset)
 
-      edition = SpecialistDocumentEdition.new(basic_edition_fields)
+      edition = SpecialistDocumentEdition.new(basic_specialist_document_fields)
       file = OpenStruct.new(original_filename: "document.pdf")
 
       edition.build_attachment(title: "baz", file: file)
@@ -69,7 +57,7 @@ class SpecialistDocumentEditionTest < ActiveSupport::TestCase
     end
 
     should "transmit attached file to asset manager when document saved" do
-      edition = SpecialistDocumentEdition.new(basic_edition_fields)
+      edition = SpecialistDocumentEdition.new(basic_specialist_document_fields)
       file = OpenStruct.new(original_filename: "document.pdf")
 
       success_response = stub("asset manager response", id: "/test-id")


### PR DESCRIPTION
This will hold a rendered version of the specialist document, including
the body in HTML format.

The rendered version will be created/updated by the specialist publisher
every time the document is published.

This is so that we don't need to add support for InlineAttachment tags
into the general-purpose govspeak helper, nor do we need to give
govuk_content_api knowledge about attachments. Instead the rendering of
the HTML will be self-contained within the specialist-publisher
application.

This fits in with the new architectural patterns envisaged Brad/Alex
Tomlins (I've discussed with Alex).
