### PR TITLE
RenderedSpecialistDocumentTest.update_or_create_by_slug

### DIFF
--- a/app/models/rendered_specialist_document.rb
+++ b/app/models/rendered_specialist_document.rb
@@ -1,5 +1,6 @@
 class RenderedSpecialistDocument
   include Mongoid::Document
+  include Mongoid::Timestamps
 
   field :slug,          type: String
   field :title,         type: String
@@ -19,4 +20,16 @@ class RenderedSpecialistDocument
 
   validates :slug, uniqueness: true
   validates_with SafeHtml
+
+  def self.create_or_update_by_slug!(attributes)
+    doc = RenderedSpecialistDocument.find_or_initialize_by(
+      slug: attributes.fetch(:slug)
+    )
+
+    doc.update_attributes!(attributes)
+  end
+
+  def self.find_by_slug(slug)
+    where(slug: slug).first
+  end
 end

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -269,6 +269,17 @@ FactoryGirl.define do
     case_state 'open'
   end
 
+  factory :rendered_specialist_document do
+    sequence(:slug) {|n| "test-rendered-specialist-document-#{n}" }
+    sequence(:title) {|n| "Test Rendered Specialist Document #{n}" }
+    summary "My summary"
+    body "<p>My body</p>"
+    opened_date '2013-04-20'
+    market_sector 'some-market-sector'
+    case_type 'a-case-type'
+    case_state 'open'
+  end
+
   factory :simple_smart_answer_edition do
     panopticon_id {
       a = create(:artefact)

--- a/test/models/rendered_specialist_document_test.rb
+++ b/test/models/rendered_specialist_document_test.rb
@@ -49,4 +49,39 @@ class RenderedSpecialistDocumentTest < ActiveSupport::TestCase
     found = RenderedSpecialistDocument.where(slug: r.slug).first
     assert_equal sample_headers, found.headers
   end
+
+  test ".create_or_update_by_slug!" do
+    slug = "a-slug"
+    original_body = "Original body"
+
+    version1_attrs= {
+      slug: slug,
+      body: original_body,
+    }
+
+    RenderedSpecialistDocument.create_or_update_by_slug!(version1_attrs)
+
+    version1 = RenderedSpecialistDocument.where(slug: slug).first
+
+    assert_not_nil version1
+
+    version2_attrs = version1_attrs.merge(
+      body: "Updated body",
+    )
+
+    RenderedSpecialistDocument.create_or_update_by_slug!(version2_attrs)
+
+    version2 = RenderedSpecialistDocument.where(slug: slug).first
+
+    assert_not_nil version2
+
+    assert_equal "Updated body", version2.body
+  end
+
+  test ".find_by_slug" do
+    created = RenderedSpecialistDocument.create!(slug: "find-by-this-slug")
+    found = RenderedSpecialistDocument.find_by_slug("find-by-this-slug")
+
+    assert_equal created, found
+  end
 end


### PR DESCRIPTION
Rendered documents must be unique by slug, this
adds a convenience method for storing a new
version of the document.
