### PR TITLE
Add embedded_in to Attachment

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -9,6 +9,8 @@ class Attachment
   field :filename
   attaches :file
 
+  embedded_in :specialist_document_edition
+
   validates_with SafeHtml
 
   def url


### PR DESCRIPTION
the embedded_in relationship is needed so that attachment removal works.
Without it, you can't remove an attachment from the list of attachments
on an edition.
