### PR TITLE
Relax slug validation to not fail on cosmetic issues 

### DIFF
--- a/app/validators/slug_validator.rb
+++ b/app/validators/slug_validator.rb
@@ -77,6 +77,11 @@ protected
   end
 
   class GovernmentPageValidator < InstanceValidator
+    def url_parts
+      # Some inside govt slugs have a . in them (eg news articles with no english translation)
+      super.map {|part| part.gsub(/\./, '') }
+    end
+
     def applicable?
       record.respond_to?(:kind) && prefixed_whitehall_format_names.include?(record.kind)
     end

--- a/test/validators/slug_validator_test.rb
+++ b/test/validators/slug_validator_test.rb
@@ -70,6 +70,10 @@ class SlugTest < ActiveSupport::TestCase
       assert document_with_slug("government/test/foo", kind: "policy").valid?
       assert document_with_slug("government/test/foo/bar", kind: "policy").valid?
     end
+
+    should "allow . in slugs" do
+      assert document_with_slug("government/world-location-news/221033.pt", kind: "news_story").valid?
+    end
   end
 
   context "Specialist documents" do


### PR DESCRIPTION
ActiveSupport's [parameterize](http://apidock.com/rails/ActiveSupport/Inflector/parameterize) method replaces characters using a regex, but then also does some cosmetic tidying (eg squashing consecutive dashes).  This has led to false positives from apps that use gems like friendly_id which use --_n_ to de-dup slugs (eg Whitehall).

Relaxing this in the base class has allowed removing a lot of the special-case behaviour from the whitehall formats.

This PR also adds support for '.' in inside govt slugs (needed for some news articles with no english translation).
