### PR TITLE
Remove business_support_identifier from BusinessSupportEdition

### DIFF
--- a/app/models/business_support_edition.rb
+++ b/app/models/business_support_edition.rb
@@ -17,7 +17,6 @@ class BusinessSupportEdition < Edition
   field :continuation_link, type: String
   field :will_continue_on, type: String
   field :contact_details, type: String
-  field :business_support_identifier, type: String
 
   field :priority,        type: Integer, default: 1
   field :business_types,  type: Array, default: []
@@ -30,13 +29,9 @@ class BusinessSupportEdition < Edition
   field :start_date,      type: Date
   field :end_date,        type: Date
 
-  index :business_support_identifier
-
   GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body, :eligibility, :evaluation, :additional_information]
 
   validate :min_must_be_less_than_max
-  validates :business_support_identifier, :presence => true
-  validate :business_support_identifier_unique
   validates_format_of :continuation_link, :with => URI::regexp(%w(http https)), :allow_blank => true
 
   # https://github.com/mongoid/mongoid/issues/1735 Really Mongoid‽
@@ -44,10 +39,8 @@ class BusinessSupportEdition < Edition
 
   @fields_to_clone = [:body, :min_value, :max_value, :max_employees, :organiser,
       :eligibility, :evaluation, :additional_information, :continuation_link,
-      :will_continue_on, :contact_details, :short_description,
-      :business_support_identifier, :priority, :business_sizes,
-      :locations, :purposes, :sectors, :stages, :support_types,
-      :start_date, :end_date]
+      :will_continue_on, :contact_details, :short_description, :priority, :business_sizes,
+      :locations, :purposes, :sectors, :stages, :support_types, :start_date, :end_date]
 
   scope :for_facets, lambda { |facets|
     where({ "$and" => facets_criteria(facets) }).order_by([:priority, :desc], [:title, :asc])
@@ -64,13 +57,6 @@ class BusinessSupportEdition < Edition
     if !min_value.nil? && !max_value.nil? && min_value > max_value
       errors[:min_value] << "Min value must be smaller than max value"
       errors[:max_value] << "Max value must be larger than min value"
-    end
-  end
-
-  def business_support_identifier_unique
-    if self.class.without_state('archived').where(:business_support_identifier => business_support_identifier,
-                        :panopticon_id.ne => panopticon_id).any?
-      errors.add(:business_support_identifier, :taken)
     end
   end
 

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -107,7 +107,6 @@ FactoryGirl.define do
   end
 
   factory :business_support_edition, :parent => :edition, :class => "BusinessSupportEdition" do
-    sequence(:business_support_identifier) {|n| "identifier-#{n}" }
   end
 
   factory :guide_edition do |ge|

--- a/test/models/business_support_edition_test.rb
+++ b/test/models/business_support_edition_test.rb
@@ -20,7 +20,6 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
     support.continuation_link = "http://www.gov.uk"
     support.will_continue_on = "The GOVUK website"
     support.contact_details = "123 The Street, Townsville, UK. 07324 123456"
-    support.business_support_identifier = "123-4-5"
 
     support.priority = 2
     support.business_sizes << "up-to-249"
@@ -48,7 +47,6 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
     assert_equal "http://www.gov.uk", support.continuation_link
     assert_equal "The GOVUK website", support.will_continue_on
     assert_equal "123 The Street, Townsville, UK. 07324 123456", support.contact_details
-    assert_equal "123-4-5", support.business_support_identifier
 
     assert_equal 2, support.priority
     assert_equal ["up-to-249"], support.business_sizes
@@ -68,33 +66,6 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
     support.max_value = 50
 
     refute support.valid?
-  end
-
-  should "require a business_support_identifier" do
-    support = FactoryGirl.build(:business_support_edition, :business_support_identifier => '')
-    assert ! support.valid?, "expected business support edition not to be valid"
-  end
-
-  context "business support identifier uniqueness" do
-    setup do
-      @support = FactoryGirl.build(:business_support_edition, panopticon_id: @artefact.id)
-      @another_artefact = FactoryGirl.create(:artefact)
-    end
-    should "have a unique business support identifier" do
-      another_support = FactoryGirl.create(:business_support_edition, panopticon_id: @another_artefact.id,
-                                          :business_support_identifier => "this-should-be-unique")
-      @support.business_support_identifier = "this-should-be-unique"
-      assert !@support.valid?, "business_support_identifier should be unique"
-      @support.business_support_identifier = "this-is-different"
-      assert @support.valid?, "business_support_identifier should be unique"
-    end
-
-    should "not consider archived editions when evaluating uniqueness" do
-      another_support = FactoryGirl.create(:business_support_edition, panopticon_id: @another_artefact.id,
-                                           :business_support_identifier => "this-should-be-unique", :state => "archived")
-      @support.business_support_identifier = "this-should-be-unique"
-      assert @support.valid?, "business_support should be valid"
-    end
   end
 
   context "numeric field validations" do
@@ -154,7 +125,6 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
     support = FactoryGirl.create(:business_support_edition,
                                  :panopticon_id => @artefact.id,
                                  :state => "published",
-                                 :business_support_identifier => "1234",
                                  :short_description => "Short description of support format",
                                  :body => "Body to be cloned",
                                  :min_value => 1,
@@ -179,7 +149,6 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
 
     new_support = support.build_clone
 
-    assert_equal support.business_support_identifier, new_support.business_support_identifier
     assert_equal support.short_description, new_support.short_description
     assert_equal support.body, new_support.body
     assert_equal support.min_value, new_support.min_value


### PR DESCRIPTION
business_support_identifier is no longer needed to couple Imminence data to the edition.
 https://www.pivotaltracker.com/story/show/67823412
