### PR TITLE
Fix Scheduled Publishing for Completed Transactions

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -186,7 +186,7 @@ module Workflow
   end
 
   def edition_changes
-    if self.whole_body.empty?
+    if self.whole_body.blank?
       false
     else
       my_body, their_body = [self, self.published_edition].map do |edition|

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -347,6 +347,11 @@ class WorkflowTest < ActiveSupport::TestCase
     assert_equal "badger\n\nmushroom\n\nsnake\n\nend", edition_two.edition_changes.to_s
   end
 
+  test "edition_changes should return false if the whole body is nil" do
+    edition = FactoryGirl.create(:completed_transaction_edition, body: nil)
+    refute edition.edition_changes
+  end
+
   test "an edition can be moved into archive state" do
     user, other_user = template_users
 


### PR DESCRIPTION
the scheduled content had body set to nil,
so it errored trying to create edition_history.
