### PR TITLE
Uncap ‘Publishing Platform’

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GOV.UK Content Models
 
-A gem containing the shared models for the GOV.UK Publishing Platform, including [Panopticon](https://github.com/alphagov/panopticon) and [Publisher](https://github.com/alphagov/publisher).
+A gem containing the shared models for the GOV.UK publishing platform, including [Panopticon](https://github.com/alphagov/panopticon) and [Publisher](https://github.com/alphagov/publisher).
 
 This is a continual **work in progress**.


### PR DESCRIPTION
Unlike the Performance Platform, which is a known, named thing, the publishing platform is less formal.
