### PR TITLE
Validations should not run if need_ids is nil

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -377,10 +377,13 @@ class Artefact
   end
 
   def filter_out_empty_need_ids
+    return if need_ids.blank?
     need_ids.reject!(&:blank?)
   end
 
   def format_of_new_need_ids
+    return if need_ids.blank?
+
     # http://api.rubyonrails.org/classes/ActiveModel/Dirty.html
     new_need_ids = need_ids_was.blank? ? need_ids : need_ids - need_ids_was
     errors.add(:need_ids, "must be six-digit integers") if new_need_ids.any? {|need_id| need_id !~ /^\d{6}$/ }

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -97,6 +97,13 @@ class ArtefactTest < ActiveSupport::TestCase
       assert_empty FactoryGirl.build(:artefact).need_ids
     end
 
+    should "do validations if nil" do
+      artefact = FactoryGirl.create(:artefact, need_ids: ["100001"])
+      artefact.need_ids = nil
+
+      assert_nothing_raised { artefact.valid? }
+    end
+
     should "filter out empty strings" do
       artefact = FactoryGirl.create(:artefact, need_ids: ["", "100002"])
       assert_equal ["100002"], artefact.reload.need_ids


### PR DESCRIPTION
There are artefacts not tied to `need_ids`, and having a `need_ids` field set to `nil` is okay. so we need to respect that.
