### PR TITLE
Prevent a Mongo error when tag_ids are set to nil

### DIFF
--- a/app/traits/taggable.rb
+++ b/app/traits/taggable.rb
@@ -59,8 +59,12 @@ module Taggable
     # as documented on http://mongoid.org/en/mongoid/docs/documents.html
     tags
 
+    # Make sure that 'values' is an array. This stops the method blowing up
+    # if nil is provided.
+    values_as_array = Array(values)
+
     # This will raise a Tag::MissingTags exception unless all the tags exist
-    new_tags = Tag.by_tag_ids!(values, tag_type)
+    new_tags = Tag.by_tag_ids!(values_as_array, tag_type)
 
     @tags.reject! { |t| t.tag_type == tag_type }
     @tags += new_tags

--- a/test/traits/taggable_test.rb
+++ b/test/traits/taggable_test.rb
@@ -111,4 +111,16 @@ class TaggableTest < ActiveSupport::TestCase
 
     assert_equal ['bacon'], @item.keyword_ids
   end
+
+  test "can set tags of type to be nil" do
+    @item.section_ids = nil
+    @item.save!
+
+    assert_equal [], @item.section_ids
+
+    @item.sections = nil
+    @item.save!
+
+    assert_equal [], @item.section_ids
+  end
 end


### PR DESCRIPTION
At present, when the tag ids for a type of tag are set to nil (eg. `organisation_ids = nil`), the operation will raise an error as the MongoDB query is expecting an array.

This changes the writer method to make sure we only request tag IDs as an array when we fetch tags from the database.
