### PR TITLE
Fix specialist tag validation

### DIFF
--- a/app/validators/tag_id_validator.rb
+++ b/app/validators/tag_id_validator.rb
@@ -1,17 +1,37 @@
 class TagIdValidator < ActiveModel::Validator
 
   def validate(record)
-    unless valid_tag_id?(record.tag_id)
+    unless valid_tag_id?(record)
       record.errors[:tag_id] << "ID must be valid in a URL and have no more than one slash"
     end
   end
 
 private
 
-  def valid_tag_id?(tag_id)
-    tag_id.to_s.match(/\A[a-z0-9\-\/]+\Z/) &&
-      tag_id.to_s.count('/') <= 1 &&
-      ! tag_id.to_s.end_with?('/')
+  def valid_tag_id?(tag)
+    tag_contains_correct_characters(tag.tag_id) &&
+    tag_doesnt_end_with_slash(tag.tag_id) &&
+    tag_contains_correct_number_of_slashes(tag.tag_id, child?: tag_is_child_tag?(tag))
+  end
+
+  def tag_contains_correct_characters(tag_id)
+    tag_id =~ %r{^[a-z0-9/-]+$}
+  end
+
+  def tag_doesnt_end_with_slash(tag_id)
+    !tag_id.end_with?('/')
+  end
+
+  def tag_contains_correct_number_of_slashes(tag_id, options = {})
+    if options[:child?]
+      tag_id.count('/') <= 1
+    else
+      tag_id.count('/') == 0
+    end
+  end
+
+  def tag_is_child_tag?(tag)
+    tag.respond_to?(:parent_id) && tag.parent_id.present?
   end
 
 end

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
   end
 
   factory :tag do
-    sequence(:tag_id) { |n| "crime-and-justice/the-police-#{n}" }
+    sequence(:tag_id) { |n| "crime-and-justice-#{n}" }
     sequence(:title) { |n| "The title #{n}" }
     tag_type "section"
   end

--- a/test/models/artefact_tag_test.rb
+++ b/test/models/artefact_tag_test.rb
@@ -2,18 +2,16 @@ require "test_helper"
 
 class ArtefactTagTest < ActiveSupport::TestCase
 
-  TEST_SECTIONS = [
-    ['crime', 'Crime'], ['crime/the-police', 'The Police'], ['crime/batman', 'Batman']
-  ]
   TEST_KEYWORDS = [['cheese', 'Cheese'], ['bacon', 'Bacon']]
   TEST_LEGACY_SOURCES = [
     ['businesslink', 'Business Link'], ['directgov', 'Directgov'], ['dvla', 'DVLA']
   ]
 
   setup do
-    TEST_SECTIONS.each do |tag_id, title|
-      FactoryGirl.create(:tag, :tag_id => tag_id, :tag_type => 'section', :title => title)
-    end
+    parent_section = FactoryGirl.create(:tag, :tag_id => 'crime', :tag_type => 'section', :title => 'Crime')
+    FactoryGirl.create(:tag, :tag_id => 'crime/the-police', :tag_type => 'section', :title => 'The Police', :parent_id => parent_section.id)
+    FactoryGirl.create(:tag, :tag_id => 'crime/batman', :tag_type => 'section', :title => 'Batman', :parent_id => parent_section.id)
+
     TEST_KEYWORDS.each do |tag_id, title|
       FactoryGirl.create(:tag, :tag_id => tag_id, :tag_type => 'keyword', :title => title)
     end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -648,20 +648,5 @@ class ArtefactTest < ActiveSupport::TestCase
       assert_equal [], @artefact.related_artefacts_grouped_by_distance["section"]
       assert_equal ["pear", "banana"], @artefact.related_artefacts_grouped_by_distance["other"].map(&:slug)
     end
-
-    should "return no section level related artefacts if the primary section has no parent_id" do
-      FactoryGirl.create(:tag, :tag_id => "fruit/multiple", :tag_type => 'section', :title => "Multiple fruits", :parent_id => nil)
-
-      @artefact.primary_section = "fruit/multiple"
-      @artefact.related_artefacts = [
-        Artefact.create!(slug: "fig", name: "Fig", kind: "guide", sections: ["fruit/multiple"], need_ids: ["100001"], owning_app: "x"),
-        Artefact.create!(slug: "strawberry", name: "Strawberry", kind: "guide", sections: ["fruit/simple"], need_ids: ["100001"], owning_app: "x")
-      ]
-      @artefact.save!
-
-      assert_equal ["fig"], @artefact.related_artefacts_grouped_by_distance["subsection"].map(&:slug)
-      assert_equal [], @artefact.related_artefacts_grouped_by_distance["section"]
-      assert_equal ["strawberry"], @artefact.related_artefacts_grouped_by_distance["other"].map(&:slug)
-    end
   end
 end

--- a/test/traits/taggable_test.rb
+++ b/test/traits/taggable_test.rb
@@ -3,14 +3,13 @@ require 'test_helper'
 # This test relies on the fact that artefact uses the taggable module
 class TaggableTest < ActiveSupport::TestCase
 
-  TEST_SECTIONS = [['crime', 'Crime'], ['crime/the-police', 'The Police'],
-    ['crime/batman', 'Batman']]
   TEST_KEYWORDS = [['cheese', 'Cheese'], ['bacon', 'Bacon']]
 
   setup do
-    TEST_SECTIONS.each do |tag_id, title|
-      FactoryGirl.create(:tag, :tag_id => tag_id, :tag_type => 'section', :title => title)
-    end
+    parent_section = FactoryGirl.create(:tag, :tag_id => 'crime', :tag_type => 'section', :title => 'Crime')
+    FactoryGirl.create(:tag, :tag_id => 'crime/the-police', :tag_type => 'section', :title => 'The Police', :parent_id => parent_section.id)
+    FactoryGirl.create(:tag, :tag_id => 'crime/batman', :tag_type => 'section', :title => 'Batman', :parent_id => parent_section.id)
+
     TEST_KEYWORDS.each do |tag_id, title|
       FactoryGirl.create(:tag, :tag_id => tag_id, :tag_type => 'keyword', :title => title)
     end

--- a/test/validators/tag_id_validator_test.rb
+++ b/test/validators/tag_id_validator_test.rb
@@ -40,13 +40,19 @@ class TagIdValidatorTest < ActiveSupport::TestCase
     assert dummy.errors.has_key?(:tag_id)
   end
 
-  should "permit a tag id containing a slash" do
-    dummy = Dummy.new(tag_id: "parent-tag-id/child-tag-id")
+  should "permit a child tag id containing a slash" do
+    dummy = Dummy.new(tag_id: "parent-tag-id/child-tag-id", parent_id: 1)
     assert dummy.valid?
   end
 
-  should "not permit more than one slash in a tag id" do
-    dummy = Dummy.new(tag_id: "parent-tag-id/more/than/one/slash")
+  should "not permit a parent tag id containing a slash" do
+    dummy = Dummy.new(tag_id: "an-invalid/parent-tag-id", parent_id: nil)
+    refute dummy.valid?
+    assert dummy.errors.has_key?(:tag_id)
+  end
+
+  should "not permit a child tag id with more than one slash" do
+    dummy = Dummy.new(tag_id: "parent-tag-id/two/slashes", parent_id: 1)
     refute dummy.valid?
     assert dummy.errors.has_key?(:tag_id)
   end


### PR DESCRIPTION
Tag slugs should only be allowed to contain a slash if they're a child tag.
