### PR TITLE
Add withdrawn state

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -155,7 +155,7 @@ class Artefact
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true, slug: true
   validates :kind, inclusion: { in: lambda { |x| FORMATS } }
-  validates :state, inclusion: { in: ["draft", "live", "archived"] }
+  validates :state, inclusion: { in: ["draft", "live", "archived", "withdrawn"] }
   validates :owning_app, presence: true
   validates :language, inclusion: { in: ["en", "cy"] }
   validates_with CannotEditSlugIfEverPublished

--- a/app/models/specialist_document_edition.rb
+++ b/app/models/specialist_document_edition.rb
@@ -30,6 +30,10 @@ class SpecialistDocumentEdition
       transition draft: :published
     end
 
+    event :withdraw do
+      transition published: :withdrawn
+    end
+
     event :archive do
       transition all => :archived, :unless => :archived?
     end


### PR DESCRIPTION
Artefact and SpecialistDocumentEdition gain a 'withdrawn' state.

There are current no tests for the state transitions, happy to add them if necessary.
