### PR TITLE
Add manual change notes

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -83,6 +83,7 @@ class Artefact
     "custom-application"      => ["custom-application"], # In this case the owning_app is overriden. eg calendars, licencefinder
     "travel-advice-publisher" => ["travel-advice"],
     "specialist-publisher"    => ["manual",
+                                  "manual-change-notes",
                                   "manual-section",
                                   "specialist-document"],
     "finder-api"              => ["finder"],

--- a/app/validators/slug_validator.rb
+++ b/app/validators/slug_validator.rb
@@ -7,6 +7,7 @@ class SlugValidator < ActiveModel::EachValidator
       HelpPageValidator,
       GovernmentPageValidator,
       ManualPageValidator,
+      ManualChangeNotesValidator,
       SpecialistDocumentPageValidator,
       BrowsePageValidator,
       DefaultValidator
@@ -19,6 +20,10 @@ protected
   class InstanceValidator < Struct.new(:record, :attribute, :value)
     def starts_with?(expected_prefix)
       value.to_s.start_with?(expected_prefix)
+    end
+
+    def ends_with?(expected_suffix)
+      value.to_s.end_with?(expected_suffix)
     end
 
     def of_kind?(expected_kind)
@@ -122,6 +127,44 @@ protected
     def validate_guidance_prefix!
       unless starts_with?('guidance/')
         record.errors[attribute] << 'must have a guidance/ prefix'
+      end
+    end
+
+    def validate_parts_as_slugs!
+      unless url_parts.all? { |url_part| valid_slug?(url_part) }
+        record.errors[attribute] << 'must be usable in a URL'
+      end
+    end
+  end
+
+  class ManualChangeNotesValidator < InstanceValidator
+    def applicable?
+      of_kind?('manual-change-notes')
+    end
+
+    def validate!
+      validate_number_of_parts!
+      validate_guidance_prefix!
+      validate_updates_suffix!
+      validate_parts_as_slugs!
+    end
+
+  private
+    def validate_number_of_parts!
+      unless url_parts.size == 3
+        record.errors[attribute] << 'must contain three path parts'
+      end
+    end
+
+    def validate_guidance_prefix!
+      unless starts_with?('guidance/')
+        record.errors[attribute] << 'must have a guidance/ prefix'
+      end
+    end
+
+    def validate_updates_suffix!
+      unless ends_with?('/updates')
+        record.errors[attribute] << 'must have a /updates suffix'
       end
     end
 

--- a/test/validators/slug_validator_test.rb
+++ b/test/validators/slug_validator_test.rb
@@ -104,6 +104,38 @@ class SlugTest < ActiveSupport::TestCase
     end
   end
 
+  context "Manual change notes" do
+    should "allow slugs of the form guidance/manual-slug/updates" do
+      assert document_with_slug("guidance/a-manual/updates",
+                                kind: "manual-change-notes").valid?
+    end
+
+    should "refuse slugs that don't start with guidance/" do
+      refute document_with_slug("manuals/a-manual/updates",
+                                kind: "manual-change-notes").valid?
+    end
+
+    should "refuse slugs that don't end with /updates" do
+      refute document_with_slug("guidance/a-manual/change-notes",
+                                kind: "manual-change-notes").valid?
+    end
+
+    should "refuse slugs that don't have a manual-slug" do
+      refute document_with_slug("guidance/change-notes",
+                                kind: "manual-change-notes").valid?
+    end
+
+    should "refuse slugs that have extra sections" do
+      refute document_with_slug("guidance/a-manual/a-section/updates",
+                                kind: "manual-change-notes").valid?
+    end
+
+    should "not allow invalid path segments" do
+      refute document_with_slug("guidance/bad.manual.slug/updates",
+                                kind: "manual-change-notes").valid?
+    end
+  end
+
   context "Manual pages" do
     should "allow slugs starting guidance/" do
       refute document_with_slug("manuals/a-manual", kind: "manual").valid?


### PR DESCRIPTION
We want to expose change notes for manuals. A manual lives at `/guidance/:manual_slug` and the change notes for it will live at `/guidance/:manual_slug/updates`.

This pull request adds a new artefact type, `manual-change-notes`, and adds a custom slug validator for it.

Part of https://trello.com/c/mjsAameQ/126-expose-the-change-note-data-from-the-content-api-3
