### PR TITLE
Show multiple link validation errors at once.

### DIFF
--- a/app/validators/link_validator.rb
+++ b/app/validators/link_validator.rb
@@ -18,21 +18,22 @@ class LinkValidator < ActiveModel::Validator
       (\{:rel=["']external["']\})?  # optional :rel=external in literal curly brackets.
     }x
 
-    errors = []
+    errors = Set.new
 
     string.scan(link_regex) do |match|
 
-      error = if match[0] !~ %r{^(?:https?://|mailto:|/)}
-        'Internal links must start with a forward slash eg [link text](/link-destination). External links must start with http://, https://, or mailto: eg [external link text](https://www.google.co.uk)'
-      elsif match[1]
-        %q-Don't include hover text in links. Delete the text in quotation marks eg "This appears when you hover over the link."-
-      elsif match[2]
-        'Delete {:rel="external"} in links.'
+      if match[0] !~ %r{^(?:https?://|mailto:|/)}
+        errors << 'Internal links must start with a forward slash eg [link text](/link-destination). External links must start with http://, https://, or mailto: eg [external link text](https://www.google.co.uk).'
+      end
+      if match[1]
+        errors << %q-Don't include hover text in links. Delete the text in quotation marks eg "This appears when you hover over the link."-
+      end
+      if match[2]
+        errors << 'Delete {:rel="external"} in links.'
       end
 
-      errors << error if error
     end
-    errors
+    errors.to_a
   end
 
   protected

--- a/test/validators/link_validator_test.rb
+++ b/test/validators/link_validator_test.rb
@@ -22,15 +22,25 @@ class LinkValidatorTest < ActiveSupport::TestCase
       doc = Dummy.new(body: "abc [internal](/internal)")
       assert doc.valid?
     end
-    should "start not contain hover text" do
-      doc = Dummy.new(body: 'abc [foobar](foobar.com "hover")')
+    should "not contain hover text" do
+      doc = Dummy.new(body: 'abc [foobar](http://foobar.com "hover")')
       assert doc.invalid?
       assert_includes doc.errors.keys, :body
     end
-    should "start not set rel=external" do
-      doc = Dummy.new(body: 'abc [foobar](foobar.com){:rel="external"}')
+    should "not set rel=external" do
+      doc = Dummy.new(body: 'abc [foobar](http://foobar.com){:rel="external"}')
       assert doc.invalid?
       assert_includes doc.errors.keys, :body
+    end
+    should "show multiple errors" do
+      doc = Dummy.new(body: 'abc [foobar](foobar.com "bar"){:rel="external"}')
+      assert doc.invalid?
+      assert_equal 3, doc.errors[:body].first.length
+    end
+    should "only show each error once" do
+      doc = Dummy.new(body: 'abc [link1](foobar.com), ghi [link2](bazquux.com)')
+      assert doc.invalid?
+      assert_equal 1, doc.errors[:body].first.length
     end
   end
 end


### PR DESCRIPTION
When there is more than one thing wrong with a link, show all the errors rather than just the first.
