### PR TITLE
Validate links in govspeak fields only during update

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -48,7 +48,7 @@ class Edition
   validates :version_number, presence: true, uniqueness: {scope: :panopticon_id}
   validates :panopticon_id, presence: true
   validates_with SafeHtml
-  validates_with LinkValidator
+  validates_with LinkValidator, on: :update
 
   before_save :check_for_archived_artefact
   before_destroy :destroy_artefact

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -83,6 +83,23 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal programme.parts.count, ProgrammeEdition::DEFAULT_PARTS.length
   end
 
+  context "link validation" do
+    should "not be done when the edition is created" do
+      assert_difference 'AnswerEdition.count', 1 do
+        FactoryGirl.create(:answer_edition, body: 'abc [foobar](http://foobar.com "hover")')
+      end
+    end
+
+    should "be done when an existing edition is updated" do
+      edition = FactoryGirl.create(:answer_edition, body: 'abc [foobar](http://foobar.com "hover")')
+
+      edition.body += "some update"
+
+      refute edition.valid?
+      assert_include edition.errors.full_messages, %q<Body ["Don't include hover text in links. Delete the text in quotation marks eg \\"This appears when you hover over the link.\\""]>
+    end
+  end
+
   test "it should build a clone" do
     edition = FactoryGirl.create(:guide_edition,
                                   state: "published",


### PR DESCRIPTION
https://www.agileplannerapp.com/boards/173808/cards/4288

earlier we validated these links even on creating
a draft edition from an existing published edition.
that would prevent the draft edition from getting
created, and made it difficult to correct those
errors.
