### PR TITLE
Validate links on any attribute changes

### DIFF
--- a/app/validators/link_validator.rb
+++ b/app/validators/link_validator.rb
@@ -1,10 +1,8 @@
 class LinkValidator < ActiveModel::Validator
   def validate(record)
-    record.changes.each do |field_name, (_, new_value)|
-      if govspeak_fields(record).include?(field_name.to_sym)
-        messages = errors(new_value)
-        record.errors[field_name] << messages if messages
-      end
+    govspeak_field_names(record).each do |govspeak_field_name|
+      messages = errors(record.read_attribute(govspeak_field_name))
+      record.errors[govspeak_field_name] << messages if messages
     end
   end
 
@@ -38,7 +36,7 @@ class LinkValidator < ActiveModel::Validator
 
   protected
 
-  def govspeak_fields(record)
+  def govspeak_field_names(record)
     if record.class.const_defined?(:GOVSPEAK_FIELDS)
       record.class.const_get(:GOVSPEAK_FIELDS)
     else

--- a/test/validators/link_validator_test.rb
+++ b/test/validators/link_validator_test.rb
@@ -5,6 +5,7 @@ class LinkValidatorTest < ActiveSupport::TestCase
     include Mongoid::Document
 
     field "body", type: String
+    field "assignee", type: String
     GOVSPEAK_FIELDS = [:body]
 
     validates_with LinkValidator
@@ -22,24 +23,39 @@ class LinkValidatorTest < ActiveSupport::TestCase
       doc = Dummy.new(body: "abc [internal](/internal)")
       assert doc.valid?
     end
+
     should "not contain hover text" do
       doc = Dummy.new(body: 'abc [foobar](http://foobar.com "hover")')
       assert doc.invalid?
       assert_includes doc.errors.keys, :body
     end
+
     should "not set rel=external" do
       doc = Dummy.new(body: 'abc [foobar](http://foobar.com){:rel="external"}')
       assert doc.invalid?
       assert_includes doc.errors.keys, :body
     end
+
     should "show multiple errors" do
       doc = Dummy.new(body: 'abc [foobar](foobar.com "bar"){:rel="external"}')
       assert doc.invalid?
       assert_equal 3, doc.errors[:body].first.length
     end
+
     should "only show each error once" do
       doc = Dummy.new(body: 'abc [link1](foobar.com), ghi [link2](bazquux.com)')
       assert doc.invalid?
+      assert_equal 1, doc.errors[:body].first.length
+    end
+
+    should "be validated when any attribute of the document changes" do
+      # already published document having link validation errors
+      doc = Dummy.new(body: 'abc [link1](foobar.com), ghi [link2](bazquux.com)')
+      doc.save(validate: false)
+
+      doc.assignee = "4fdef0000000000000000001"
+      assert doc.invalid?
+
       assert_equal 1, doc.errors[:body].first.length
     end
   end


### PR DESCRIPTION
earlier we validated govspeak fields in an
edition only when they changed. instead, we
should validate and present all errors in
the document on every save.
