### PR TITLE
Validate govspeak links on any attribute change

### DIFF
--- a/app/validators/link_validator.rb
+++ b/app/validators/link_validator.rb
@@ -1,7 +1,10 @@
 class LinkValidator < ActiveModel::Validator
   def validate(record)
     govspeak_field_names(record).each do |govspeak_field_name|
-      messages = errors(record.read_attribute(govspeak_field_name))
+      govspeak_field_value = record.read_attribute(govspeak_field_name)
+      next if govspeak_field_value.blank?
+
+      messages = errors(govspeak_field_value)
       record.errors[govspeak_field_name] << messages if messages
     end
   end

--- a/test/validators/link_validator_test.rb
+++ b/test/validators/link_validator_test.rb
@@ -12,6 +12,15 @@ class LinkValidatorTest < ActiveSupport::TestCase
   end
 
   context "links" do
+    should "not be verified for blank govspeak fields" do
+      doc = Dummy.new(body: nil)
+
+      assert_nothing_raised do
+        doc.valid?
+      end
+      assert_empty doc.errors
+    end
+
     should "start with http[s]://, mailto: or /" do
       doc = Dummy.new(body: "abc [external](external.com)")
       assert doc.invalid?


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/4296

earlier we validated govspeak fields in an
edition only when they changed. instead, we
should validate and present all errors in
the document on every save.
