### PR TITLE
Reverting link validation on any attribute change

### DIFF
--- a/app/validators/link_validator.rb
+++ b/app/validators/link_validator.rb
@@ -1,11 +1,10 @@
 class LinkValidator < ActiveModel::Validator
   def validate(record)
-    govspeak_field_names(record).each do |govspeak_field_name|
-      govspeak_field_value = record.read_attribute(govspeak_field_name)
-      next if govspeak_field_value.blank?
-
-      messages = errors(govspeak_field_value)
-      record.errors[govspeak_field_name] << messages if messages
+    record.changes.each do |field_name, (_, new_value)|
+      if govspeak_fields(record).include?(field_name.to_sym)
+        messages = errors(new_value)
+        record.errors[field_name] << messages if messages
+      end
     end
   end
 
@@ -39,7 +38,7 @@ class LinkValidator < ActiveModel::Validator
 
   protected
 
-  def govspeak_field_names(record)
+  def govspeak_fields(record)
     if record.class.const_defined?(:GOVSPEAK_FIELDS)
       record.class.const_get(:GOVSPEAK_FIELDS)
     else

--- a/test/validators/link_validator_test.rb
+++ b/test/validators/link_validator_test.rb
@@ -5,22 +5,12 @@ class LinkValidatorTest < ActiveSupport::TestCase
     include Mongoid::Document
 
     field "body", type: String
-    field "assignee", type: String
     GOVSPEAK_FIELDS = [:body]
 
     validates_with LinkValidator
   end
 
   context "links" do
-    should "not be verified for blank govspeak fields" do
-      doc = Dummy.new(body: nil)
-
-      assert_nothing_raised do
-        doc.valid?
-      end
-      assert_empty doc.errors
-    end
-
     should "start with http[s]://, mailto: or /" do
       doc = Dummy.new(body: "abc [external](external.com)")
       assert doc.invalid?
@@ -32,39 +22,24 @@ class LinkValidatorTest < ActiveSupport::TestCase
       doc = Dummy.new(body: "abc [internal](/internal)")
       assert doc.valid?
     end
-
     should "not contain hover text" do
       doc = Dummy.new(body: 'abc [foobar](http://foobar.com "hover")')
       assert doc.invalid?
       assert_includes doc.errors.keys, :body
     end
-
     should "not set rel=external" do
       doc = Dummy.new(body: 'abc [foobar](http://foobar.com){:rel="external"}')
       assert doc.invalid?
       assert_includes doc.errors.keys, :body
     end
-
     should "show multiple errors" do
       doc = Dummy.new(body: 'abc [foobar](foobar.com "bar"){:rel="external"}')
       assert doc.invalid?
       assert_equal 3, doc.errors[:body].first.length
     end
-
     should "only show each error once" do
       doc = Dummy.new(body: 'abc [link1](foobar.com), ghi [link2](bazquux.com)')
       assert doc.invalid?
-      assert_equal 1, doc.errors[:body].first.length
-    end
-
-    should "be validated when any attribute of the document changes" do
-      # already published document having link validation errors
-      doc = Dummy.new(body: 'abc [link1](foobar.com), ghi [link2](bazquux.com)')
-      doc.save(validate: false)
-
-      doc.assignee = "4fdef0000000000000000001"
-      assert doc.invalid?
-
       assert_equal 1, doc.errors[:body].first.length
     end
   end


### PR DESCRIPTION
This revert is a temporary change, till we have a
fix which can work with all existing documents.

see [discussion](https://www.agileplannerapp.com/boards/173808/discussions/758) for more details.
