### PR TITLE
Denormalising users shouldn't need save on edition

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -11,7 +11,7 @@ module Workflow
     before_destroy :check_can_delete_and_notify
     after_destroy :notify_siblings_of_published_edition
 
-    before_save :denormalise_users
+    before_save :denormalise_users!
     after_create :notify_siblings_of_new_edition
 
     field :state, type: String, default: "draft"
@@ -113,13 +113,13 @@ module Workflow
       # collections, but share a model and relationships with eg actions.
       # Therefore, Panopticon might not find a user for an action.
       if action.requester
-        self[property] = action.requester.name
+        set(property, action.requester.name)
       end
     end
   end
 
-  def denormalise_users
-    self.assignee = assigned_to.name if assigned_to
+  def denormalise_users!
+    set(:assignee, assigned_to.name) if assigned_to
     update_user_action("creator",   [Action::CREATE, Action::NEW_VERSION])
     update_user_action("publisher", [Action::PUBLISH])
     update_user_action("archiver",  [Action::ARCHIVE])

--- a/app/models/workflow_actor.rb
+++ b/app/models/workflow_actor.rb
@@ -18,14 +18,14 @@ module WorkflowActor
   def record_action(edition, type, options={})
     type = Action.const_get(type.to_s.upcase)
     action = edition.new_action(self, type, options)
-    edition.save! # force callbacks for denormalisation
+    edition.denormalise_users!
     action
   end
 
   def record_action_without_validation(edition, type, options={})
     type = Action.const_get(type.to_s.upcase)
     action = edition.new_action_without_validation(self, type, options)
-    edition.save! # force callbacks for denormalisation
+    edition.denormalise_users!
     action
   end
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/4296

Denormalising users is a process that's setting values for a few columns, which doesn't need the the entire validation chain or callbacks to execute. there are no validations related to denormalisation, all the more reason for it to be a plain `set` operation.

there's a cost involved here of multiple update queries being fired, but that should be lower than triggering callbacks and validation chain repeatedly.
