### PR TITLE
Assigning an edition doesn't require save

### DIFF
--- a/app/models/workflow_actor.rb
+++ b/app/models/workflow_actor.rb
@@ -139,13 +139,8 @@ module WorkflowActor
   end
 
   def assign(edition, recipient)
-    edition.assigned_to_id = recipient.id
-
-    # We're saving the edition here as the controller treats assignment as a
-    # special case.
-    # The controller saves the publication, then updates assignment.
-    edition.save! and edition.reload
-    record_action edition, __method__, recipient: recipient
+    edition.set(:assigned_to_id, recipient.id)
+    record_action edition.reload, __method__, recipient: recipient
   end
 
   private


### PR DESCRIPTION
assignment updates the `assigned_to_id` on a edition
and doesn't require the entire validation and callback
chain to get executed.
