### PR TITLE
Errors shouldn't block receiving fact check

### DIFF
--- a/app/models/workflow_actor.rb
+++ b/app/models/workflow_actor.rb
@@ -93,10 +93,13 @@ module WorkflowActor
     take_action(edition, __method__, details)
   end
 
-  # Advances state if possible (i.e. if in "fact_check" state)
   # Always records the action.
   def receive_fact_check(edition, details)
-    edition.receive_fact_check
+    # advance state if possible (i.e. if in "fact_check" state),
+    # save separately without validation
+    # http://rubydoc.info/github/pluginaweek/state_machine/StateMachine/Machine:event
+    edition.state_event = :receive_fact_check
+    edition.save(validate: false)
     # Fact checks are processed async, so the user doesn't get an opportunity
     # to retry without the content that (inadvertantly) fails validation, which happens frequently.
     record_action_without_validation(edition, :receive_fact_check, details)

--- a/test/models/workflow_actor_test.rb
+++ b/test/models/workflow_actor_test.rb
@@ -58,6 +58,18 @@ class WorkflowActorTest < ActiveSupport::TestCase
     end
   end
 
+  context "#receive_fact_check" do
+    should "transition an edition with link validation errors to fact_check_received state" do
+      edition = FactoryGirl.create(:guide_edition_with_two_parts, state: :fact_check)
+      # Internal links must start with a forward slash eg [link text](/link-destination)
+      edition.parts.first.update_attribute(:body, "[register and tax your vehicle](registering-an-imported-vehicle)")
+
+      assert edition.invalid?
+      assert User.new.receive_fact_check(edition, {})
+      assert_equal "fact_check_received", edition.reload.state
+    end
+  end
+
   context "#schedule_for_publishing" do
     setup do
       @user = FactoryGirl.build(:user)


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5005

the edition mentioned in the story had invalid links in one of its parts. errors were causing it to remain in 'fact_check' even after calling event 'receive_fact_check'.

it seems unnecessary to validate the document when we're receiving fact check response, hence this change.
