### PR TITLE
Add draft tag functionality to `Tag.by_tag_id/s`.

### DIFF
--- a/app/traits/taggable.rb
+++ b/app/traits/taggable.rb
@@ -95,12 +95,6 @@ module Taggable
   end
 
   def tags(include_draft = false)
-    all_tags = Tag.by_tag_ids(tag_ids)
-
-    if include_draft
-      all_tags
-    else
-      all_tags.reject {|tag| tag.state == 'draft' }
-    end
+    Tag.by_tag_ids(tag_ids, draft: include_draft)
   end
 end


### PR DESCRIPTION
Also permits tag type to be provided via an options hash, while retaining backwards compatibility.

Part of https://www.pivotaltracker.com/story/show/73970494
