### PR TITLE
Allow archiving siblings with validation errors

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -236,7 +236,7 @@ class Edition
   end
 
   def was_published
-    previous_siblings.all.each(&:archive)
+    previous_siblings.each { |s| s.perform_event_without_validations(:archive) }
     notify_siblings_of_published_edition
   end
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -221,6 +221,13 @@ module Workflow
     published? ? 'Published editions' : 'Editions scheduled for publishing'
   end
 
+  def perform_event_without_validations(event)
+    # http://rubydoc.info/github/pluginaweek/state_machine/StateMachine/Machine:event
+    # pass false to transition state without performing state machine actions
+    public_send(event, false)
+    save(validate: false)
+  end
+
   private
 
     def publish_at_is_in_the_future

--- a/app/models/workflow_actor.rb
+++ b/app/models/workflow_actor.rb
@@ -95,11 +95,7 @@ module WorkflowActor
 
   # Always records the action.
   def receive_fact_check(edition, details)
-    # advance state if possible (i.e. if in "fact_check" state),
-    # save separately without validation
-    # http://rubydoc.info/github/pluginaweek/state_machine/StateMachine/Machine:event
-    edition.receive_fact_check(false)
-    edition.save(validate: false)
+    edition.perform_event_without_validations(:receive_fact_check)
     # Fact checks are processed async, so the user doesn't get an opportunity
     # to retry without the content that (inadvertantly) fails validation, which happens frequently.
     record_action_without_validation(edition, :receive_fact_check, details)


### PR DESCRIPTION
https://govuk.zendesk.com/agent/#/tickets/780846
www.agileplannerapp.com/boards/173808/cards/5005
1. extracting a method to perform state machine transitions bypassing validations
2. moving all comments in one place
3. removing unnecessary `save!` calls in tests.
