### PR TITLE
Represent tag tuple keys as strings, not symbols

### DIFF
--- a/app/traits/taggable.rb
+++ b/app/traits/taggable.rb
@@ -63,10 +63,10 @@ module Taggable
 
     Tag.validate_tag_ids(tag_ids, tag_type)
 
-    current_tags = attributes['tags'].reject {|t| t[:tag_type] == tag_type }
+    current_tags = attributes['tags'].reject {|t| t['tag_type'] == tag_type }
 
     self.tags = current_tags + tag_ids.map {|tag_id|
-      {tag_id: tag_id, tag_type: tag_type}
+      {'tag_id' => tag_id, 'tag_type' => tag_type}
     }
   end
 
@@ -77,7 +77,7 @@ module Taggable
   def set_primary_tag_of_type(tag_type, tag_id)
     Tag.validate_tag_ids([tag_id], tag_type)
 
-    tag_tuple = {tag_id: tag_id, tag_type: tag_type}
+    tag_tuple = {'tag_id' => tag_id, 'tag_type' => tag_type}
 
     current_tags = attributes['tags'].dup
     current_tags.delete(tag_tuple)
@@ -90,7 +90,7 @@ module Taggable
   end
 
   def tags=(new_tag_tuples)
-    self.tag_ids = new_tag_tuples.map {|tuple| tuple[:tag_id] }
+    self.tag_ids = new_tag_tuples.map {|tuple| tuple['tag_id'] }
     super(new_tag_tuples)
   end
 

--- a/test/models/artefact_tag_test.rb
+++ b/test/models/artefact_tag_test.rb
@@ -47,10 +47,10 @@ class ArtefactTagTest < ActiveSupport::TestCase
     a.keywords = ['bacon']
 
     expected_tags = [
-      { tag_id: "crime", tag_type: "section" },
-      { tag_id: "crime/the-police", tag_type: "section" },
-      { tag_id: "businesslink", tag_type: "legacy_source" },
-      { tag_id: "bacon", tag_type: "keyword" },
+      { "tag_id" => "crime", "tag_type" => "section" },
+      { "tag_id" => "crime/the-police", "tag_type" => "section" },
+      { "tag_id" => "businesslink", "tag_type" => "legacy_source" },
+      { "tag_id" => "bacon", "tag_type" => "keyword" },
     ]
     assert_equal ["crime", "crime/the-police", "businesslink", "bacon"], a.tag_ids
     assert_equal expected_tags, a.attributes["tags"]


### PR DESCRIPTION
We currently use symbols as the keys for the hash tuples that store 
tag and tag type data on artefacts. This sometimes results in a mixture 
of both symbols and strings in use, because the tuples are returned from 
the database with string-based keys. This causes problems, as we always 
use symbols in the code to find tag IDs and dedupe tags of the same type.

Rather than use `with_indifferent_access`, the simplest way to fix this
to use string-based keys across the board.
