### PR TITLE
Add International Development Fund Artefact Type

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -84,6 +84,7 @@ class Artefact
     "travel-advice-publisher" => ["travel-advice"],
     "specialist-publisher"    => ["aaib_report",
                                   "cma_case",
+                                  "international_development_fund",
                                   "manual",
                                   "manual-change-history",
                                   "manual-section",


### PR DESCRIPTION
In order to publish International Development Funds from Specialist Publisher, the format type must be added to the `Artefact` model.
