### PR TITLE
Make Tag#parent return the tag's parent even if it is draft.

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -63,7 +63,7 @@ class Tag
   end
 
   def parent
-    Tag.by_tag_id(parent_id, self.tag_type) if has_parent?
+    Tag.by_tag_id(parent_id, type: self.tag_type, draft: true) if has_parent?
   end
 
   def unique_title

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -128,6 +128,13 @@ class TagTest < ActiveSupport::TestCase
     assert_includes Tag.validators.map(&:class), TagIdValidator
   end
 
+  test "#parent returns the parent even if the parent is draft" do
+    parent = FactoryGirl.create(:tag, state: 'draft')
+    child = FactoryGirl.create(:tag, state: 'draft', parent_id: parent.tag_id)
+
+    assert_equal parent, child.parent
+  end
+
   context "state" do
     setup do
       @atts = { tag_type: 'section', tag_id: 'test', title: 'Test' }


### PR DESCRIPTION
This was causing tags to be returned via the API with blank parents, even though the parent existed in draft and draft tags had been requested.

The niggle this introduces is that if one were to request only live tags and there was a live child with a draft parent, that draft parent would be included in the response.

We are currently planning to prevent live children with draft parents so this should be a non-issue.
