### PR TITLE
Add published-at to RenderedSpecialistDocument

### DIFF
--- a/app/models/rendered_specialist_document.rb
+++ b/app/models/rendered_specialist_document.rb
@@ -9,6 +9,7 @@ class RenderedSpecialistDocument
   field :title,                  type: String
   field :summary,                type: String
   field :body,                   type: String
+  field :published_at,           type: DateTime
 
   field :details,                type: Hash
 


### PR DESCRIPTION
[trello ticket](https://trello.com/c/K1rcmRCw/242-bug-fix-updated-at-dates-on-all-specialist-publisher-documents-so-that-they-don-t-change-when-a-draft-is-saved-2)

We want to store published at separately from updated_at so we control when it's updated, not mongoid.
