### PR TITLE
Release version 17.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 17.0.0
+* BREAKING CHANGE: Upgrade govspeak gem dependency.
+  * This modifies how the SafeHtml validator will behave. It now permits tags
+    it didn't before.
+
 ## 16.2.0
 * Add published_at field to RenderedSpecialistDocument
 

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "16.2.0"
+  VERSION = "17.0.0"
 end


### PR DESCRIPTION
This is a breaking change because it modifies the behaviour of the `SafeHtml` validator due to changes in the behaviour of the new version of `sanitize` included by Govspeak version 2.0.
