### PR TITLE
Release with a compatible govspeak version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.0.1
+* govspeak v2.0.0 unintentionally broke content models.
+  upgrading to a version that includes a compatibility fix.
+
 ## 17.0.0
 * BREAKING CHANGE: Upgrade govspeak gem dependency.
   * This modifies how the SafeHtml validator will behave. It now permits tags

--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gds-api-adapters", ">= 10.9.0"
 
   gem.add_dependency "gds-sso",          ">= 7.0.0", "< 10.0.0"
-  gem.add_dependency "govspeak",         "~> 2.0.0"
+  gem.add_dependency "govspeak",         "~> 2.0", ">= 2.0.2"
   # Mongoid 2.5.0 supports the newer 1.7.x and 1.8.x Mongo drivers
   gem.add_dependency "mongoid",          "~> 2.5"
   gem.add_dependency "plek"

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "17.0.0"
+  VERSION = "17.0.1"
 end


### PR DESCRIPTION
govspeak v2.0.0 unintentionally broke content models.
upgrading to a version that includes a compatibility fix.

details about the breaking change can be found [here](https://github.com/alphagov/govspeak/pull/34).
