### PR TITLE
Editions can be marked as being in beta

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -11,6 +11,7 @@ class Edition
   field :business_proposition, type: Boolean,  default: false
 
   field :title,                type: String
+  field :in_beta,              type: Boolean,  default: false
   field :created_at,           type: DateTime, default: lambda { Time.zone.now }
   field :publish_at,           type: DateTime
   field :overview,             type: String

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -54,6 +54,14 @@ class EditionTest < ActiveSupport::TestCase
     assert a.errors[:title].any?
   end
 
+  test "it is not in beta by default" do
+    refute FactoryGirl.build(:guide_edition).in_beta?
+  end
+
+  test "it can be in beta" do
+    assert FactoryGirl.build(:guide_edition, in_beta: true).in_beta?
+  end
+
   test "it should give a friendly (legacy supporting) description of its format" do
     a = LocalTransactionEdition.new
     assert_equal "LocalTransaction", a.format


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5418

As a GDS content designer
I want to show GOV.UK end users that a piece of
mainstream content is not yet the official source
and is still in beta
So that I can trial content with the public and
gather evidence to make it even better
