### PR TITLE
Release 17.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 17.1.0
+* Added `in_beta` field to `Edition`
+
 ## 17.0.0
 * BREAKING CHANGE: Upgrade govspeak gem dependency.
   * This modifies how the SafeHtml validator will behave. It now permits tags

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "17.0.0"
+  VERSION = "17.1.0"
 end


### PR DESCRIPTION
Added `in_beta` field to `Edition`.

details [here](https://github.com/alphagov/govuk_content_models/pull/210).
