### PR TITLE
Make Artefact#as_json handle missing tags gracefully

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -213,7 +213,6 @@ class Artefact
   def as_json(options={})
     super.tap { |hash|
       if hash["tag_ids"]
-        Tag.validate_tag_ids(hash["tag_ids"])
         hash["tags"] = Tag.by_tag_ids(hash["tag_ids"]).map(&:as_json)
       else
         hash["tag_ids"] = []

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -552,6 +552,13 @@ class ArtefactTest < ActiveSupport::TestCase
           ]
           assert_equal expected, hash['tags']
         end
+
+        should "omit non-existent tags referenced from the tag_ids array" do
+          @a.tag_ids << 'batman'
+          hash = @a.as_json
+
+          assert_equal %w(justice businesslink), hash['tags'].map {|t| t[:id] }
+        end
       end
     end
   end


### PR DESCRIPTION
Previously this was blowing up if tag_ids referenced non-existent tags.
This changes it to just omit these tags from the resulting tags array.

This change is necessary to allow the JSON view of the panopticon artefacts index to work (it currently blows up on various pages).  This in turn is necessary to allow us to seed the url-arbiter with the data that's currently in panopticon.
