### PR TITLE
Revert "Bump Govspeak to allow/require ~> 3.0"

### DIFF
--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gds-api-adapters", ">= 10.9.0"
 
   gem.add_dependency "gds-sso",          ">= 7.0.0", "< 10.0.0"
-  gem.add_dependency "govspeak",         "~> 3.0"
+  gem.add_dependency "govspeak",         "~> 2.0.0"
   # Mongoid 2.5.0 supports the newer 1.7.x and 1.8.x Mongo drivers
   gem.add_dependency "mongoid",          "~> 2.5"
   gem.add_dependency "plek"


### PR DESCRIPTION
This is going to require more than just this change.  Reverting for now after conversation with @jamiecobbett 
so as to not block other changes.

This reverts commit 6403139e1e0f627d0c55957d75e446ef3389976e.
