### PR TITLE
Clean up Govspeak validation

### DIFF
--- a/app/validators/safe_html.rb
+++ b/app/validators/safe_html.rb
@@ -18,25 +18,9 @@ class SafeHtml < ActiveModel::Validator
   end
 
   def check_string(record, field_name, string)
-    if govspeak_fields(record).include?(field_name)
-      unless Govspeak::Document.new(string).valid?
-        error = "cannot include invalid Govspeak or JavaScript"
-        record.errors.add(field_name, error)
-      end
-    else
-      unless Govspeak::HtmlValidator.new(string).valid?
-        error = "cannot include invalid HTML or JavaScript"
-        record.errors.add(field_name, error)
-      end
-    end
-  end
-
-private
-  def govspeak_fields(record)
-    if record.class.const_defined?(:GOVSPEAK_FIELDS)
-      record.class.const_get(:GOVSPEAK_FIELDS)
-    else
-      []
+    unless Govspeak::Document.new(string).valid?
+      error = "cannot include invalid Govspeak, invalid HTML or JavaScript"
+      record.errors.add(field_name, error)
     end
   end
 end


### PR DESCRIPTION
For some time (years), the `HtmlValidator` has validated the string you pass it as if it were Govspeak. This code gave the impression that it instead treated it as HTML. The intention here was originally to avoid false positives for content which wouldn't be passed through Govspeak, but happened to have content that has meaning in Govspeak. This is apparently not an issue.

I tested it successfully with Publisher. The only difference is a slightly different validation message, but no tests seem to depend on that.
