### PR TITLE
Add drug safety update artefact kind

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -84,6 +84,7 @@ class Artefact
     "travel-advice-publisher" => ["travel-advice"],
     "specialist-publisher"    => ["aaib_report",
                                   "cma_case",
+                                  "drug_safety_update",
                                   "international_development_fund",
                                   "manual",
                                   "manual-change-history",


### PR DESCRIPTION
Adding DSU artefact kind owned by Specialist Publisher. [Ticket](https://trello.com/c/4drpVQbv/275-dsu-finder-add-support-to-specialist-publisher-for-publishing-drug-safety-updates-2).
