### PR TITLE
Add Medical Safety Alert Artefact Kind

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -88,6 +88,7 @@ class Artefact
                                   "manual",
                                   "manual-change-history",
                                   "manual-section",
+                                  "medical-safety-alert",
                                   "specialist-document"], # Deprecated: Leaving in place for legacy reasons. In future use explicit document_type
     "finder-api"              => ["finder"],
     "whitehall"               => ["announcement",


### PR DESCRIPTION
MSA artefact owning App is Specialist Publisher and relates to MHRA.
