### PR TITLE
Underscore artefact kind

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -89,8 +89,7 @@ class Artefact
                                   "manual",
                                   "manual-change-history",
                                   "manual-section",
-                                  "medical_safety_alert",
-                                  "specialist-document"], # Deprecated: Leaving in place for legacy reasons. In future use explicit document_type
+                                  "medical_safety_alert"],
     "finder-api"              => ["finder"],
     "whitehall"               => ["announcement",
                                   "authored_article",

--- a/test/validators/slug_validator_test.rb
+++ b/test/validators/slug_validator_test.rb
@@ -78,11 +78,11 @@ class SlugTest < ActiveSupport::TestCase
 
   context "Specialist documents" do
     should "all url nested one level deep" do
-      assert document_with_slug("some-finder/my-specialist-document", kind: "specialist-document").valid?
+      assert document_with_slug("some-finder/my-specialist-document", kind: "cma_case").valid?;
     end
 
     should "not allow deeper nesting" do
-      refute document_with_slug("some-finder/my-specialist-document/not-allowed", kind: "specialist-document").valid?
+      refute document_with_slug("some-finder/my-specialist-document/not-allowed", kind: "cma_case").valid?
     end
   end
 


### PR DESCRIPTION
For consistency with newest Artefcat kinds we should use underscores not dashes.

Modifies the work done here:
https://github.com/alphagov/govuk_content_models/pull/218
