### PR TITLE
Restrict allowed hosts for inline images

### DIFF
--- a/app/validators/safe_html.rb
+++ b/app/validators/safe_html.rb
@@ -1,6 +1,17 @@
 require "govspeak"
+require "plek"
 
 class SafeHtml < ActiveModel::Validator
+  ALLOWED_IMAGE_HOSTS = [
+    # URLs for the local environment
+    URI.parse(Plek.new.website_root).host, # eg www.preview.alphagov.co.uk
+    URI.parse(Plek.new.asset_root).host,   # eg assets-origin.preview.alphagov.co.uk
+
+    # Hardcode production URLs so that content copied from production is valid
+    'www.gov.uk',
+    'assets.digital.cabinet-office.gov.uk'
+  ]
+
   def validate(record)
     record.changes.each do |field_name, (old_value, new_value)|
       check_struct(record, field_name, new_value)
@@ -18,8 +29,8 @@ class SafeHtml < ActiveModel::Validator
   end
 
   def check_string(record, field_name, string)
-    unless Govspeak::Document.new(string).valid?
-      error = "cannot include invalid Govspeak, invalid HTML or JavaScript"
+    unless Govspeak::Document.new(string).valid?(allowed_image_hosts: ALLOWED_IMAGE_HOSTS)
+      error = "cannot include invalid Govspeak, invalid HTML, any JavaScript or images hosted on sites except for #{ALLOWED_IMAGE_HOSTS.join(', ')}"
       record.errors.add(field_name, error)
     end
   end

--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gds-api-adapters", ">= 10.9.0"
 
   gem.add_dependency "gds-sso",          ">= 7.0.0", "< 10.0.0"
-  gem.add_dependency "govspeak",         "~> 2.0.0"
+  gem.add_dependency "govspeak",         "~> 3.1.0"
   # Mongoid 2.5.0 supports the newer 1.7.x and 1.8.x Mongo drivers
   gem.add_dependency "mongoid",          "~> 2.5"
   gem.add_dependency "plek"

--- a/test/validators/safe_html_validator_test.rb
+++ b/test/validators/safe_html_validator_test.rb
@@ -58,6 +58,17 @@ class SafeHtmlTest < ActiveSupport::TestCase
       assert_includes dummy.errors.keys, :undeclared
     end
 
+    should "disallow images not hosted by us" do
+      dummy = Dummy.new(undeclared: '<img src="http://evil.com/trollface"/>')
+      assert dummy.invalid?
+      assert_includes dummy.errors.keys, :undeclared
+    end
+
+    should "allow images hosted by us" do
+      dummy = Dummy.new(undeclared: '<img src="http://www.dev.gov.uk/trollface"/>')
+      assert dummy.valid?
+    end
+
     should "allow plain text" do
       dummy = Dummy.new(declared: "foo bar")
       assert dummy.valid?


### PR DESCRIPTION
Otherwise an editor could include an image which could be changed to something
malicious at the whim of the website owner (or an attacker).

I'd appreciate some oversight on whether I've got the list of hostnames correct.
