### PR TITLE
Delete section field on editions

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -17,7 +17,6 @@ class Edition
   field :overview,             type: String
   field :alternative_title,    type: String
   field :slug,                 type: String
-  field :section,              type: String
   field :department,           type: String
   field :rejected_count,       type: Integer,  default: 0
   field :tags,                 type: String
@@ -154,7 +153,7 @@ class Edition
 
     real_fields_to_merge = fields_to_copy(edition_class) +
                            [:panopticon_id, :overview, :alternative_title,
-                            :slug, :section, :department]
+                            :slug, :department]
 
     real_fields_to_merge.each do |attr|
       new_edition[attr] = read_attribute(attr)
@@ -188,7 +187,6 @@ class Edition
       panopticon_id: metadata.id,
       slug: metadata.slug,
       title: metadata.name,
-      section: metadata.section,
       department: metadata.department,
       business_proposition: metadata.business_proposition)
   end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -244,7 +244,7 @@ module Workflow
     end
 
     def disallowable_change?
-      allowed_to_change = %w(slug section publish_at department business_proposition)
+      allowed_to_change = %w(slug publish_at department business_proposition)
       (changes.keys - allowed_to_change).present?
     end
 end

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -89,8 +89,6 @@ FactoryGirl.define do
     sequence(:slug) { |n| "slug-#{n}" }
     sequence(:title) { |n| "A key answer to your question #{n}" }
 
-    section "test:subsection test"
-
     after :build do |ed|
       if previous = ed.series.order(version_number: "desc").first
         ed.version_number = previous.version_number + 1

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -373,7 +373,6 @@ class ArtefactTest < ActiveSupport::TestCase
     edition.save!
 
     assert_equal artefact.name, edition.title
-    assert_equal artefact.section, edition.section
 
     artefact.name = "Babar"
     artefact.save

--- a/test/models/edition_scheduled_for_publishing_test.rb
+++ b/test/models/edition_scheduled_for_publishing_test.rb
@@ -53,15 +53,6 @@ class EditionScheduledForPublishingTest < ActiveSupport::TestCase
       assert_includes edition.errors.full_messages, "Editions scheduled for publishing can't be edited"
     end
 
-    should "allow editing fields like section" do
-      edition = FactoryGirl.create(:edition, :scheduled_for_publishing)
-
-      edition.section = 'new section'
-
-      assert edition.save
-      assert_equal edition.reload.section, 'new section'
-    end
-
     should "return false for #can_destroy?" do
       edition = FactoryGirl.build(:edition, :scheduled_for_publishing)
       refute edition.can_destroy?

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -118,7 +118,6 @@ class EditionTest < ActiveSupport::TestCase
                                   alternative_title: "Alternative test title")
     clone_edition = edition.build_clone
     assert_equal clone_edition.department, "Test dept"
-    assert_equal clone_edition.section, "test:subsection test"
     assert_equal clone_edition.overview, "I am a test overview"
     assert_equal clone_edition.alternative_title, "Alternative test title"
     assert_equal clone_edition.version_number, 2
@@ -374,7 +373,6 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should create a publication based on data imported from panopticon" do
-    section = FactoryGirl.create(:live_tag, tag_id: "test-section", title: "Test section", tag_type: "section")
     artefact = FactoryGirl.create(:artefact,
         slug: "foo-bar",
         kind: "answer",
@@ -382,13 +380,9 @@ class EditionTest < ActiveSupport::TestCase
         department: "Test dept",
         owning_app: "publisher",
     )
-    artefact.primary_section = section.tag_id
     artefact.save!
 
     a = Artefact.find(artefact.id)
-
-    assert_equal section.tag_id, artefact.primary_section.tag_id
-    assert_equal section.title, artefact.primary_section.title
     user = User.create
 
     publication = Edition.find_or_create_from_panopticon_data(artefact.id, user, {})
@@ -396,7 +390,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_kind_of AnswerEdition, publication
     assert_equal artefact.name, publication.title
     assert_equal artefact.id.to_s, publication.panopticon_id.to_s
-    assert_equal section.title, publication.section
     assert_equal artefact.department, publication.department
   end
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5444

there's this bug reported in Publisher where someone's adding a section to an artefact in Panopticon, yet the section is not showing up in the documents table in Publisher. this is because the editor adds `edition.artefact.section`, whereas Publisher shows the `edition.section` field. these 2 fields don't get synced after an edition is created from artefact metadata.

here's a proposal to delete the `edition.section` field altogether, so that we reduce coupling between these applications and don't have to worry about duplicating these fields across editions and their artefacts.

it seems that the Publisher documents table is the only place we use `edition.section`. all the more reason to switch that to use section from the artefact, and drop the `edition.section`.

taking an example of https://www.gov.uk/payslips. this edition has a section: "Work:Employment rights" its artefact has section: "Working, jobs and pensions:Your pay, tax and the National Minimum Wage". on frontend, the artefact's section is used to create breadcrumbs and report Section variable to Google Analytics. only Publisher shows the `edition.section`.
