### PR TITLE
Add regulation to artefact formats

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -120,6 +120,7 @@ class Artefact
                                   "press_release",
                                   "promotional",
                                   "publication",
+                                  "regulation",
                                   "research",
                                   "speaking_notes",
                                   "statistical_data_set",


### PR DESCRIPTION
- Adds new publication subtype from Whitehall to artefact formats

In support of story https://www.pivotaltracker.com/story/show/78637270
