### PR TITLE
Remove legacy diff code

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -33,7 +33,6 @@ class Action
   field :approved,           type: DateTime
   field :comment,            type: String
   field :comment_sanitized,  type: Boolean, default: false
-  field :diff,               type: String
   field :request_type,       type: String
   field :email_addresses,    type: String
   field :customised_message, type: String

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -275,15 +275,4 @@ class Edition
       Artefact.find(self.panopticon_id).destroy
     end
   end
-
-  def previous_edition_differences
-    return if version_number <= 1
-
-    if in_progress?
-      edition_changes.to_s # diff of current changes
-    else
-      actions.select { |a| a.request_type == 'publish' }.last.diff # diff with previous published version
-    end
-  end
-
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,4 +1,3 @@
-require "differ"
 require "state_machine"
 require "action"
 
@@ -184,17 +183,6 @@ module Workflow
 
   def previous_edition
     self.previous_published_edition || false
-  end
-
-  def edition_changes
-    if self.whole_body.blank?
-      false
-    else
-      my_body, their_body = [self, self.published_edition].map do |edition|
-        edition.whole_body.gsub("\r\n", "\n")
-      end
-      Differ.diff_by_line(my_body, their_body)
-    end
   end
 
   def notify_siblings_of_new_edition

--- a/app/models/workflow_actor.rb
+++ b/app/models/workflow_actor.rb
@@ -118,10 +118,6 @@ module WorkflowActor
   end
 
   def publish(edition, details)
-    if edition.published_edition
-      details.merge!({ diff: edition.edition_changes })
-    end
-
     take_action(edition, __method__, details)
   end
 

--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.version       = GovukContentModels::VERSION
 
   gem.add_dependency "bson_ext"
-  gem.add_dependency "differ"
   gem.add_dependency "gds-api-adapters", ">= 10.9.0"
 
   gem.add_dependency "gds-sso",          ">= 7.0.0", "< 10.0.0"

--- a/test/models/local_transaction_edition_test.rb
+++ b/test/models/local_transaction_edition_test.rb
@@ -52,27 +52,4 @@ class LocalTransactionEditionTest < ActiveSupport::TestCase
     assert lt.valid?
     assert lt.persisted?
   end
-
-  test "should create a diff between the versions when publishing a new version" do
-    make_service(149, %w{county unitary})
-    edition_one = LocalTransactionEdition.new(title: "Transaction", slug: "transaction", lgsl_code: "149", panopticon_id: @artefact.id)
-    user = User.create name: "Thomas"
-
-    edition_one.introduction = "Test"
-    edition_one.state = :ready
-    edition_one.save!
-
-    user.publish edition_one, comment: "First edition"
-
-    edition_two = edition_one.build_clone
-    edition_two.introduction = "Testing"
-    edition_two.state = :ready
-    edition_two.save!
-
-    user.publish edition_two, comment: "Second edition"
-
-    publish_action = edition_two.actions.where(request_type: "publish").last
-
-    assert_equal "{\"Test\" >> \"Testing\"}", publish_action.diff
-  end
 end


### PR DESCRIPTION
Publisher now renders diffs on the fly rather than from a pre-computed diff stored in the data store, making this code redundant.
