### PR TITLE
Copy collection fields when cloning editions.

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -155,9 +155,16 @@ class Edition
     new_edition = edition_class.new(title: self.title,
                                     version_number: get_next_version_number)
 
-    real_fields_to_merge = fields_to_copy(edition_class) +
-                           [:panopticon_id, :overview, :alternative_title,
-                            :slug, :department]
+    real_fields_to_merge = fields_to_copy(edition_class) + [
+      :panopticon_id,
+      :overview,
+      :alternative_title,
+      :slug,
+      :department,
+      :browse_pages,
+      :primary_topic,
+      :additional_topics
+    ]
 
     real_fields_to_merge.each do |attr|
       new_edition[attr] = read_attribute(attr)

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1074,5 +1074,26 @@ class EditionTest < ActiveSupport::TestCase
     should "validates browse pages" do
       assert_includes Edition.validators.map(&:class), BrowsePageValidator
     end
+
+    should "retain collections across new editions" do
+      edition = FactoryGirl.create(:guide_edition,
+        panopticon_id: @artefact.id,
+        state: "published",
+        primary_topic: 'oil-and-gas/carbon-capture-and-storage',
+        additional_topics: [
+          'oil-and-gas/fields-and-wells',
+          'oil-and-gas/licensing'
+        ],
+        browse_pages: [
+          'education/school-admissions-transport',
+          'driving/drivers-lorries-buses'
+        ]
+      )
+
+      new_edition = edition.build_clone
+      assert_equal edition.primary_topic, new_edition.primary_topic
+      assert_equal edition.additional_topics, new_edition.additional_topics
+      assert_equal edition.browse_pages, new_edition.browse_pages
+    end
   end
 end


### PR DESCRIPTION
These fields operate across all edition types, and so can be safely copied.
