### PR TITLE
Validate only govspeak fields for safe html

### DIFF
--- a/app/validators/link_validator.rb
+++ b/app/validators/link_validator.rb
@@ -1,6 +1,6 @@
 class LinkValidator < ActiveModel::Validator
   def validate(record)
-    govspeak_field_names(record).each do |govspeak_field_name|
+    record.class::GOVSPEAK_FIELDS.each do |govspeak_field_name|
       govspeak_field_value = record.read_attribute(govspeak_field_name)
       next if govspeak_field_value.blank?
 
@@ -36,15 +36,4 @@ class LinkValidator < ActiveModel::Validator
     end
     errors.to_a
   end
-
-  protected
-
-  def govspeak_field_names(record)
-    if record.class.const_defined?(:GOVSPEAK_FIELDS)
-      record.class.const_get(:GOVSPEAK_FIELDS)
-    else
-      []
-    end
-  end
 end
-

--- a/app/validators/safe_html.rb
+++ b/app/validators/safe_html.rb
@@ -14,6 +14,7 @@ class SafeHtml < ActiveModel::Validator
 
   def validate(record)
     record.changes.each do |field_name, (old_value, new_value)|
+      next unless record.class::GOVSPEAK_FIELDS.include?(field_name.to_sym)
       check_struct(record, field_name, new_value)
     end
   end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5154

looking at the HTML validator in govspeak suggests that it is useful to validate that HTML generated from govspeak is safe. however, these checks seem unnecessary for non-govspeak fields, because rails ensures that safe html is rendered, and we take care to not mark user input as `.html_safe`.

this is blocking editors from adding html in the edition notes, which should be allowed.

i'll appreciate inputs from those who've worked on this area earlier to validate our understanding before we merge. git suggests: @jamiecobbett
