### PR TITLE
Add MAIB Report artefact kind

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -86,6 +86,7 @@ class Artefact
                                   "cma_case",
                                   "drug_safety_update",
                                   "international_development_fund",
+                                  "maib_report",
                                   "manual",
                                   "manual-change-history",
                                   "manual-section",


### PR DESCRIPTION
In order to transition MAIB to GOV.UK we need to add their reports as an artefact kind. Owning App is Specialist Publisher.
