### PR TITLE
Bump to 22.1.2 to add MAIB Report artefact kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 22.1.2
+
+* Allow new formats for maib_report and for an Artefact
+
 ## 22.1.1
 
 * Copy collection associations when cloning Editions

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "22.1.1"
+  VERSION = "22.1.2"
 end


### PR DESCRIPTION
This PR bumps the version to 22.1.2 which has the new MAIB Report artefact kind.
