### PR TITLE
Bump to version 23 for important_note changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 23.0.0
+
+* Remove important_notes field from Edition
+* Add IMPORTANT_NOTE and IMPORTANT_NOTE_RESOLVED request_types to Action
+* Add methods to find, create and resolve important note actions to Workflow and WorkflowActor.
+
 ## 22.2.0
 
 * Allow new formats for raib_report for Artefacts

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "22.2.0"
+  VERSION = "23.0.0"
 end


### PR DESCRIPTION
Backwards-incompatible change removes important_note field from Edition and makes important notes a type of Action.
