### PR TITLE
Record scheduled time in audit log

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -36,6 +36,7 @@ class Action
   field :comment,            type: String
   field :comment_sanitized,  type: Boolean, default: false
   field :request_type,       type: String
+  field :request_details,    type: Hash, default: {}
   field :email_addresses,    type: String
   field :customised_message, type: String
   field :created_at,         type: DateTime, default: lambda { Time.zone.now }
@@ -52,7 +53,13 @@ class Action
   end
 
   def to_s
-    request_type.humanize.capitalize
+    if request_type == SCHEDULE_FOR_PUBLISHING
+      string = "Scheduled for publishing"
+      string += " on #{request_details['scheduled_time'].strftime('%d/%m/%Y %H:%M %Z')}" if request_details['scheduled_time'].present?
+      string
+    else
+      request_type.humanize.capitalize
+    end
   end
 
   def is_fact_check_request?

--- a/app/models/workflow_actor.rb
+++ b/app/models/workflow_actor.rb
@@ -117,7 +117,9 @@ module WorkflowActor
   end
 
   def schedule_for_publishing(edition, details)
-    publish_at = details.delete(:publish_at)
+    publish_at = details.delete(:publish_at).to_time.utc
+    details.merge!(request_details: { scheduled_time: publish_at })
+
     take_action(edition, __method__, details, [publish_at])
   end
 

--- a/test/models/action_test.rb
+++ b/test/models/action_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class ActionTest < ActiveSupport::TestCase
+  test "#to_s should return the humanized version of the request type" do
+    assert_equal "Approve review", Action.new(request_type: 'approve_review').to_s
+  end
+
+  test "#to_s should contain the scheduled time when request type is SCHEDULE_FOR_PUBLISHING" do
+    assert_equal "Scheduled for publishing on 12/12/2014 00:00 UTC",
+      Action.new(:request_type => 'schedule_for_publishing',
+                 :request_details => { 'scheduled_time' => Date.parse('12/12/2014').to_time.utc }).to_s
+  end
+end

--- a/test/models/workflow_actor_test.rb
+++ b/test/models/workflow_actor_test.rb
@@ -84,7 +84,7 @@ class WorkflowActorTest < ActiveSupport::TestCase
   context "#schedule_for_publishing" do
     setup do
       @user = FactoryGirl.build(:user)
-      @publish_at = 1.day.from_now
+      @publish_at = 1.day.from_now.utc
       @activity_details = { publish_at: @publish_at, comment: "Go schedule !" }
     end
 
@@ -104,7 +104,8 @@ class WorkflowActorTest < ActiveSupport::TestCase
 
     should "record the action" do
       edition = FactoryGirl.create(:edition, state: 'ready')
-      @user.expects(:record_action).with(edition, :schedule_for_publishing, { comment: "Go schedule !" })
+      options = { comment: "Go schedule !", request_details: { scheduled_time: @publish_at } }
+      @user.expects(:record_action).with(edition, :schedule_for_publishing, options)
 
       @user.schedule_for_publishing(edition, @activity_details)
     end


### PR DESCRIPTION
Keeping a track of times at which editions were scheduled to publish will help debug issues related to scheduled publishing in mainstream publisher.
