### PR TITLE
Add major change and change summary fields

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -28,6 +28,8 @@ class Edition
   field :creator,              type: String
   field :publisher,            type: String
   field :archiver,             type: String
+  field :major_change,         type: Boolean, default: false
+  field :change_note,          type: String
 
   GOVSPEAK_FIELDS = []
 
@@ -52,6 +54,7 @@ class Edition
   validates_with SafeHtml
   validates_with LinkValidator, on: :update
   validates_with TopicValidator, BrowsePageValidator
+  validates_presence_of :change_note, if: :major_change
 
   before_save :check_for_archived_artefact
   before_destroy :destroy_artefact

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -108,6 +108,29 @@ class EditionTest < ActiveSupport::TestCase
     end
   end
 
+  context "change note" do
+    should "be a minor change by default" do
+      refute Edition.new.major_change
+    end
+    should "not be valid for major changes with a blank change note" do
+      edition = Edition.new(major_change: true, change_note: "")
+      refute edition.valid?
+      assert edition.errors.has_key?(:change_note)
+    end
+    should "be valid for major changes with a change note" do
+      edition = Edition.new(title: "Edition", version_number: 1, panopticon_id: 123, major_change: true, change_note: "Changed")
+      assert edition.valid?
+    end
+    should "be valid when blank for minor changes" do
+      edition = Edition.new(title: "Edition", version_number: 1, panopticon_id: 123, change_note: "")
+      assert edition.valid?
+    end
+    should "be valid when populated for minor changes" do
+      edition = Edition.new(title: "Edition", version_number: 1, panopticon_id: 123, change_note: "Changed")
+      assert edition.valid?
+    end
+  end
+
   test "it should build a clone" do
     edition = FactoryGirl.create(:guide_edition,
                                   state: "published",


### PR DESCRIPTION
With presence validation for change summary when making a major change.

Part of [this story](https://www.agileplannerapp.com/boards/173808/cards/6320).
