### PR TITLE
Correct request type for create edition

### DIFF
--- a/lib/govuk_content_models/action_processors.rb
+++ b/lib/govuk_content_models/action_processors.rb
@@ -5,7 +5,7 @@ module GovukContentModels
   module ActionProcessors
     REQUEST_TYPE_TO_PROCESSOR = {
       assign: 'AssignProcessor',
-      create_edition: 'CreateEditionProcessor',
+      create: 'CreateEditionProcessor',
       request_review: 'RequestReviewProcessor',
       approve_review: 'ApproveReviewProcessor',
       send_fact_check: 'SendFactCheckProcessor',


### PR DESCRIPTION
continuing with: https://github.com/alphagov/govuk_content_models/pull/245

for a create edition action the request type should be recorded as 'create', not 'create_edition'. this ensures that we show the correct message under 'History and Notes', and send the correct notification out to editors when an edition is created.
