### PR TITLE
Release 24.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 24.0.1
+
+* Corrected the request_type recorded in actions for a create_edition
+action to 'create', a deviation introduced by changes in 24.0.0.
+
 ## 24.0.0
 
 * Major clean-up which replaced `WorkflowActor` with `ActionProcessors`.

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "24.0.0"
+  VERSION = "24.0.1"
 end


### PR DESCRIPTION
Corrected the `request_type` recorded in actions for a `create_edition` action to 'create', a deviation introduced by changes in release 24.0.0.
