### PR TITLE
Use version numbers for picking current edition

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -209,7 +209,7 @@ class Edition
     elsif edition.present?
       scope.where(version_number: edition).first
     else
-      scope.where(state: "published").order_by(:created_at).last
+      scope.where(state: "published").order(version_number: "desc").first
     end
   end
 


### PR DESCRIPTION
In Edition.find_and_identify, if no edition is supplied, the currently
published edition is returned.

However, the method picks the currently published edition by picking the
edition which has the highest created_at value out of the published
editions.  Due to the workflow we have in creating editions, the
created_at order is currently the same as the version number, but it
seems clearer to use the version number for picking the latest edition
(and I believe that is what we use for this elsewhere).

This commit simply changes the `Edition.find_and_identify` method to
pick the published edition with the highest version number (when given
no edition).

I can't find any code currently using this method in this manner (though
I have an open PR on publisher to use it), and this change shouldn't
affect the results, so this is unlikely to break anything.
