### PR TITLE
Add disabled field to User

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,10 @@ class User
   field "permissions",         type: Array
   field "remotely_signed_out", type: Boolean, default: false
   field "organisation_slug",   type: String
-  
+  field "disabled",            type: Boolean, default: false
+
+  index "disabled"
+
   GOVSPEAK_FIELDS = []
 
   # Setup accessible (or protected) attributes for your model
@@ -29,6 +32,8 @@ class User
   attr_accessible :email, :name, :uid, :permissions, as: :oauth
 
   scope :alphabetized, order_by(name: :asc)
+  scope :enabled, any_of({ :disabled.exists => false },
+                         { :disabled.in => [false, nil] })
 
   validates_with SafeHtml
 

--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "bson_ext"
   gem.add_dependency "gds-api-adapters", ">= 10.9.0"
 
-  gem.add_dependency "gds-sso",          ">= 7.0.0", "< 10.0.0"
+  gem.add_dependency "gds-sso",          ">= 10.0.0"
   gem.add_dependency "govspeak",         "~> 3.1.0"
   # Mongoid 2.5.0 supports the newer 1.7.x and 1.8.x Mongo drivers
   gem.add_dependency "mongoid",          "~> 2.5"
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "factory_girl", "3.3.0"
   gem.add_development_dependency "gem_publisher", "1.2.0"
   gem.add_development_dependency "mocha", "0.13.3"
-  gem.add_development_dependency "multi_json", "1.3.7" # Pinned to allow dependency resolution
+  gem.add_development_dependency "multi_json"
   gem.add_development_dependency "rake", "0.9.2.2"
   gem.add_development_dependency "webmock", "1.8.7"
   gem.add_development_dependency "shoulda-context", "1.0.0"

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -15,6 +15,10 @@ FactoryGirl.define do
     end
   end
 
+  factory :disabled_user, parent: :user do
+    disabled true
+  end
+
   factory :tag do
     sequence(:tag_id) { |n| "crime-and-justice-#{n}" }
     sequence(:title) { |n| "The title #{n}" }

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -20,6 +20,17 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "", user.to_s
   end
 
+  test "should return enabled users" do
+    disabled = FactoryGirl.create(:user, disabled: true)
+
+    FactoryGirl.create(:user).unset(:disabled)
+    FactoryGirl.create(:user, disabled: false)
+    FactoryGirl.create(:user, disabled: nil)
+
+    assert_equal 3, User.enabled.count
+    refute User.enabled.include? disabled
+  end
+
   test "should create new user with oauth params" do
     auth_hash = {
       "uid" => "1234abcd",
@@ -30,7 +41,8 @@ class UserTest < ActiveSupport::TestCase
       },
       "extra" => {
         "user" => {
-          "permissions" => ["signin"]
+          "permissions" => ["signin"],
+          "disabled" => false,
         }
       }
     }
@@ -39,6 +51,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "user@example.com", user.email
     assert_equal "Luther Blisset", user.name
     assert_equal(["signin"], user.permissions)
+    refute user.disabled?
   end
 
   test "should find and update the user with oauth params" do
@@ -53,7 +66,8 @@ class UserTest < ActiveSupport::TestCase
       },
       "extra" => {
         "user" => {
-          "permissions" => []
+          "permissions" => [],
+          "disabled" => true
         }
       }
     }
@@ -62,6 +76,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "new@m.com", user.email
     assert_equal "New", user.name
     assert_equal([], user.permissions)
+    assert user.disabled?
   end
 
   test "should create insecure gravatar URL" do


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5886

This helps filter-out users based on their Signon state. For example, Signon would inform Publisher about a user being suspended by setting `disabled` in the user json.

Unpinning multi_json because the reason for which it was added seems to have been resolved.
