### PR TITLE
Release 24.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 24.1.0
+
+* Use version numbers for picking current edition in 'Edition.find_and_identify'
+* Changed to depend on the latest major release of gds-sso [10.0.0]
+  which requires a `disabled` field to be defined on the `User` model.
+  This field mirrors the user state in Signon.
+
 ## 24.0.1
 
 * Corrected the request_type recorded in actions for a create_edition

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "24.0.1"
+  VERSION = "24.1.0"
 end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5886
- Use version numbers for picking current edition in 'Edition.find_and_identify'
- Changed to depend on the latest major release of gds-sso [10.0.0] that requires a `disabled` field to be defined on the `User` model. This field mirrors the user state in Signon.

Releases: https://github.com/alphagov/govuk_content_models/pull/248, https://github.com/alphagov/govuk_content_models/pull/249
