### PR TITLE
Add change tracking fields to Artefact

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -46,6 +46,8 @@ class Artefact
   field "specialist_body",      type: String
   field "language",             type: String,  default: "en"
   field "need_extended_font",   type: Boolean, default: false
+  field "latest_change_note",   type: String
+  field "public_timestamp",     type: DateTime
 
   index "slug", :unique => true
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/82952014

This adds two new fields to the Artefact model, to contain the latest change note for a content item, and the public timestamp at which it was last changed.

These will be included in the document that is sent to Rummager in subsequent work to Panopticon.
