### PR TITLE
Remove the `alternative_title` field from the `Edition` class

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -17,7 +17,6 @@ class Edition
   field :created_at,           type: DateTime, default: lambda { Time.zone.now }
   field :publish_at,           type: DateTime
   field :overview,             type: String
-  field :alternative_title,    type: String
   field :slug,                 type: String
   field :department,           type: String
   field :rejected_count,       type: Integer,  default: 0
@@ -125,9 +124,9 @@ class Edition
 
   def indexable_content_without_parts
     if respond_to?(:body)
-      "#{alternative_title} #{Govspeak::Document.new(body).to_text}".strip
+      "#{Govspeak::Document.new(body).to_text}".strip
     else
-      alternative_title
+      ""
     end
   end
 
@@ -162,7 +161,6 @@ class Edition
     real_fields_to_merge = fields_to_copy(edition_class) + [
       :panopticon_id,
       :overview,
-      :alternative_title,
       :slug,
       :department,
       :browse_pages,

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -137,12 +137,10 @@ class EditionTest < ActiveSupport::TestCase
                                   panopticon_id: @artefact.id,
                                   version_number: 1,
                                   department: "Test dept",
-                                  overview: "I am a test overview",
-                                  alternative_title: "Alternative test title")
+                                  overview: "I am a test overview")
     clone_edition = edition.build_clone
     assert_equal clone_edition.department, "Test dept"
     assert_equal clone_edition.overview, "I am a test overview"
-    assert_equal clone_edition.alternative_title, "Alternative test title"
     assert_equal clone_edition.version_number, 2
   end
 
@@ -194,7 +192,6 @@ class EditionTest < ActiveSupport::TestCase
         version_number: 1,
         department: "Test dept",
         overview: "I am a test overview",
-        alternative_title: "Alternative test title",
         video_url: "http://www.youtube.com/watch?v=dQw4w9WgXcQ"
     )
     new_edition = edition.build_clone AnswerEdition
@@ -205,7 +202,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal new_edition.state, "draft"
     assert_equal new_edition.department, "Test dept"
     assert_equal new_edition.overview, "I am a test overview"
-    assert_equal new_edition.alternative_title, "Alternative test title"
     assert_equal new_edition.whole_body, edition.whole_body
   end
 
@@ -216,8 +212,7 @@ class EditionTest < ActiveSupport::TestCase
         panopticon_id: @artefact.id,
         version_number: 1,
         department: "Test dept",
-        overview: "I am a test overview",
-        alternative_title: "Alternative test title"
+        overview: "I am a test overview"
     )
     new_edition = edition.build_clone AnswerEdition
 
@@ -227,7 +222,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal new_edition.state, "draft"
     assert_equal new_edition.department, "Test dept"
     assert_equal new_edition.overview, "I am a test overview"
-    assert_equal new_edition.alternative_title, "Alternative test title"
     assert_equal new_edition.whole_body, edition.whole_body
   end
 
@@ -239,7 +233,6 @@ class EditionTest < ActiveSupport::TestCase
         version_number: 1,
         department: "Test dept",
         overview: "I am a test overview",
-        alternative_title: "Alternative test title",
         more_information: "More information",
         alternate_methods: "Alternate methods"
     )
@@ -251,7 +244,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal new_edition.state, "draft"
     assert_equal new_edition.department, "Test dept"
     assert_equal new_edition.overview, "I am a test overview"
-    assert_equal new_edition.alternative_title, "Alternative test title"
     assert_equal new_edition.whole_body, edition.whole_body
   end
 
@@ -263,7 +255,6 @@ class EditionTest < ActiveSupport::TestCase
         version_number: 1,
         department: "Test dept",
         overview: "I am a test overview",
-        alternative_title: "Alternative test title",
         body: "Test body"
     )
     new_edition = edition.build_clone TransactionEdition
@@ -274,7 +265,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal new_edition.state, "draft"
     assert_equal new_edition.department, "Test dept"
     assert_equal new_edition.overview, "I am a test overview"
-    assert_equal new_edition.alternative_title, "Alternative test title"
     assert_equal new_edition.more_information, "Test body"
   end
 
@@ -286,7 +276,6 @@ class EditionTest < ActiveSupport::TestCase
         version_number: 1,
         department: "Test dept",
         overview: "I am a test overview",
-        alternative_title: "Alternative test title",
         video_url: "http://www.youtube.com/watch?v=dQw4w9WgXcQ"
     )
     new_edition = edition.build_clone TransactionEdition
@@ -297,7 +286,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal new_edition.state, "draft"
     assert_equal new_edition.department, "Test dept"
     assert_equal new_edition.overview, "I am a test overview"
-    assert_equal new_edition.alternative_title, "Alternative test title"
     assert_equal new_edition.more_information, edition.whole_body
   end
 
@@ -309,7 +297,6 @@ class EditionTest < ActiveSupport::TestCase
         version_number: 1,
         department: "Test dept",
         overview: "I am a test overview",
-        alternative_title: "Alternative test title"
     )
     new_edition = edition.build_clone TransactionEdition
 
@@ -319,7 +306,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal new_edition.state, "draft"
     assert_equal new_edition.department, "Test dept"
     assert_equal new_edition.overview, "I am a test overview"
-    assert_equal new_edition.alternative_title, "Alternative test title"
     assert_equal new_edition.more_information, edition.whole_body
   end
 
@@ -331,7 +317,6 @@ class EditionTest < ActiveSupport::TestCase
         version_number: 1,
         department: "Test dept",
         overview: "I am a test overview",
-        alternative_title: "Alternative test title"
     )
     new_edition = edition.build_clone GuideEdition
 
@@ -341,7 +326,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal new_edition.state, "draft"
     assert_equal new_edition.department, "Test dept"
     assert_equal new_edition.overview, "I am a test overview"
-    assert_equal new_edition.alternative_title, "Alternative test title"
   end
 
   test "Cloning between types with parts" do
@@ -998,10 +982,10 @@ class EditionTest < ActiveSupport::TestCase
     end
 
     context "for a single part thing" do
-      should "have the normalised content of that part" do
-        edition = FactoryGirl.create(:guide_edition, :state => 'ready', :title => 'one part thing', :alternative_title => 'alternative one part thing', panopticon_id: FactoryGirl.create(:artefact).id)
+      should "have an empty string for an edition with no body" do
+        edition = FactoryGirl.create(:guide_edition, :state => 'ready', :title => 'one part thing', panopticon_id: FactoryGirl.create(:artefact).id)
         edition.publish
-        assert_equal "alternative one part thing", edition.indexable_content
+        assert_equal "", edition.indexable_content
       end
     end
 

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -27,7 +27,7 @@ class WorkflowTest < ActiveSupport::TestCase
     user = User.create(name: "Ben")
     other_user = User.create(name: "James")
 
-    guide = user.create_edition(:guide, panopticon_id: @artefact.id, overview: "My Overview", title: "My Title", slug: "my-title", alternative_title: "My Other Title")
+    guide = user.create_edition(:guide, panopticon_id: @artefact.id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
 
     request_review(user, edition)
@@ -141,7 +141,7 @@ class WorkflowTest < ActiveSupport::TestCase
     user = User.create(name: "Ben")
     other_user = User.create(name: "James")
 
-    edition = user.create_edition(:guide, panopticon_id: @artefact.id, overview: "My Overview", title: "My Title", slug: "my-title", alternative_title: "My Other Title")
+    edition = user.create_edition(:guide, panopticon_id: @artefact.id, overview: "My Overview", title: "My Title", slug: "my-title")
 
     request_review(user, edition)
     approve_review(other_user, edition)
@@ -158,7 +158,7 @@ class WorkflowTest < ActiveSupport::TestCase
     user = User.create(name: "Ben")
     other_user = User.create(name: "James")
 
-    guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title", alternative_title: "My Other Title")
+    guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
 
     request_review(user, edition)
@@ -173,7 +173,7 @@ class WorkflowTest < ActiveSupport::TestCase
     user = User.create(name: "Ben")
     other_user = User.create(name: "James")
 
-    guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title", alternative_title: "My Other Title")
+    guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
 
     request_review(user, edition)
@@ -189,7 +189,7 @@ class WorkflowTest < ActiveSupport::TestCase
     user = User.create(name: "Ben")
     other_user = User.create(name: "James")
 
-    guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title", alternative_title: "My Other Title")
+    guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
 
     request_review(user, edition)
@@ -206,7 +206,7 @@ class WorkflowTest < ActiveSupport::TestCase
     other_user = User.create(name: "James")
     another_user = User.create(name: "Fiona")
 
-    guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title", alternative_title: "My Other Title")
+    guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
 
     request_review(user, edition)


### PR DESCRIPTION
This field is no longer supported in the Publisher application now
that alphagov/publisher#292 has been merged.
