### PR TITLE
Bump to v24.3.0 to pick up removal of `alternative_title`

### DIFF
--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "24.2.0"
+  VERSION = "24.3.0"
 end


### PR DESCRIPTION
This picks up changes that have since been made as part of #253.
