### PR TITLE
Release 26.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 26.0.0
+
+- Removes `Expectation` model and introduces `need_to_know` `String` field on
+  Transaction, LocalTransaction and Place editions to store the expectations
+  as a govspeak field.
+
 ## 25.0.0
 
 - Removes the `alternative_title` field from the `Edition` class.

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "25.0.0"
+  VERSION = "26.0.0"
 end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8707

Removes `Expectation` model and introduces `need_to_know` `String` field on Transaction, LocalTransaction and Place editions to store the expectations as a govspeak field.

Releases: https://github.com/alphagov/govuk_content_models/pull/257
