### PR TITLE
Add review_requested_at field to Edition

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -31,6 +31,7 @@ class Edition
   field :archiver,             type: String
   field :major_change,         type: Boolean, default: false
   field :change_note,          type: String
+  field :review_requested_at,  type: DateTime
 
   GOVSPEAK_FIELDS = []
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -32,6 +32,10 @@ module Workflow
         edition.was_published
       end
 
+      before_transition on: :request_review do |edition, transition|
+        edition.review_requested_at = Time.zone.now
+      end
+
       event :request_review do
         transition [:draft, :amends_needed] => :in_review
       end
@@ -84,6 +88,10 @@ module Workflow
 
       event :archive do
         transition all => :archived, :unless => :archived?
+      end
+
+      state :in_review do
+        validates_presence_of :review_requested_at
       end
 
       state :scheduled_for_publishing do

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -112,8 +112,10 @@ class WorkflowTest < ActiveSupport::TestCase
     guide = template_guide
     user = User.create(name:"Ben")
     refute guide.in_review?
+    refute guide.review_requested_at
     request_review(user, guide)
     assert guide.in_review?
+    assert_in_delta Time.zone.now.to_f, guide.review_requested_at.to_f, 1.0
   end
 
   test "guide workflow" do


### PR DESCRIPTION
To facilitate [ordering Editions efficiently in Publisher](https://www.agileplannerapp.com/boards/173808/cards/8711) the time a review was requested needs to be a field.
