### PR TITLE
Add reviewer field to Edition

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -26,6 +26,7 @@ class Edition
   field :additional_topics,    type: Array, default: []
 
   field :assignee,             type: String
+  field :reviewer,             type: String
   field :creator,              type: String
   field :publisher,            type: String
   field :archiver,             type: String
@@ -56,7 +57,7 @@ class Edition
   validates :panopticon_id, presence: true
   validates_with SafeHtml
   validates_with LinkValidator, on: :update
-  validates_with TopicValidator, BrowsePageValidator
+  validates_with TopicValidator, BrowsePageValidator, ReviewerValidator
   validates_presence_of :change_note, if: :major_change
 
   before_save :check_for_archived_artefact

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -28,6 +28,10 @@ module Workflow
         edition.publish_at = nil
       end
 
+      before_transition on: [:approve_review, :request_amendments] do |edition, transition|
+        edition.reviewer = nil
+      end
+
       after_transition on: :publish do |edition, transition|
         edition.was_published
       end

--- a/app/validators/reviewer_validator.rb
+++ b/app/validators/reviewer_validator.rb
@@ -1,0 +1,20 @@
+class ReviewerValidator < ActiveModel::Validator
+  def validate(record)
+    if record.reviewer
+      validate_reviewer_in_review(record)
+      validate_reviewer_not_assignee(record)
+    end
+  end
+
+private
+  def validate_reviewer_in_review(record)
+    unless record.in_review?
+      record.errors.add(:reviewer, "can only be set when in review")
+    end
+  end
+  def validate_reviewer_not_assignee(record)
+    if record.assigned_to and record.reviewer == record.assigned_to.name
+      record.errors.add(:reviewer, "can't be the assignee")
+    end
+  end
+end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -131,6 +131,15 @@ class EditionTest < ActiveSupport::TestCase
     end
   end
 
+  test "reviewer cannot be the assignee" do
+    user = FactoryGirl.create(:user)
+    edition = Edition.new(title: "Edition", version_number: 1, panopticon_id: 123,
+                          state: "in_review", review_requested_at: Time.zone.now, assigned_to: user)
+    edition.reviewer = user.name
+    refute edition.valid?
+    assert edition.errors.has_key?(:reviewer)
+  end
+
   test "it should build a clone" do
     edition = FactoryGirl.create(:guide_edition,
                                   state: "published",


### PR DESCRIPTION
https://www.agileplannerapp.com/boards/173808/cards/8712
- Nilify this field when the Edition transitions out of 'in_review'.
- Validate that the reviewer isn't the assignee.
- Validate the reviewer field by state.
