### PR TITLE
Add index for updated_at field

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -66,6 +66,7 @@ class Edition
   index "assigned_to_id"
   index [["panopticon_id", Mongo::ASCENDING], ["version_number", Mongo::ASCENDING]], :unique => true
   index "state"
+  index "updated_at"
 
   class << self; attr_accessor :fields_to_clone end
   @fields_to_clone = []


### PR DESCRIPTION
This is the default sort field in Publisher, so an index would be nice.
