### PR TITLE
Add a way to unassign a User from an Edition

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,4 +77,8 @@ class User
   def assign(edition, recipient)
     GovukContentModels::ActionProcessors::AssignProcessor.new(self, edition, { recipient_id: recipient.id }).processed_edition
   end
+
+  def unassign(edition)
+    GovukContentModels::ActionProcessors::AssignProcessor.new(self, edition).processed_edition
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -123,6 +123,25 @@ class UserTest < ActiveSupport::TestCase
     assert_equal(worker_user, publication.assigned_to)
   end
 
+  test "Edition can be unassigned" do
+    boss_user = User.create(:name => "Mat")
+    worker_user = User.create(:name => "Grunt")
+
+    publication = boss_user.create_edition(:answer, title: "test answer", slug: "test", panopticon_id: @artefact.id)
+    boss_user.assign(publication, worker_user)
+    publication.save
+    publication.reload
+
+    assert_equal(worker_user, publication.assigned_to)
+
+    boss_user.unassign(publication)
+    publication.save
+    publication.reload
+
+    assert_nil publication.assigned_to
+  end
+
+
   test "should default to a collection called 'users'" do
     assert_equal "users", User.collection_name
   end


### PR DESCRIPTION
Part of [this story](https://www.agileplannerapp.com/boards/173808/cards/8900) to unassign a `User` from an `Edition`.
