### PR TITLE
Add uniqueness constraint on uid

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User
   field "organisation_slug",   type: String
   field "disabled",            type: Boolean, default: false
 
+  index "uid", unique: true
   index "disabled"
 
   GOVSPEAK_FIELDS = []

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -599,8 +599,8 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should be assigned to the last assigned recipient" do
-    alice = User.create(name: "alice")
-    bob = User.create(name: "bob")
+    alice = FactoryGirl.create(:user, name: "alice")
+    bob = FactoryGirl.create(:user, name: "bob")
     edition = FactoryGirl.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
     alice.assign(edition, bob)
     assert_equal bob, edition.assigned_to

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -112,8 +112,8 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "Edition becomes assigned to user when user is assigned an edition" do
-    boss_user = User.create(:name => "Mat")
-    worker_user = User.create(:name => "Grunt")
+    boss_user = FactoryGirl.create(:user, :name => "Mat")
+    worker_user = FactoryGirl.create(:user, :name => "Grunt")
 
     publication = boss_user.create_edition(:answer, title: "test answer", slug: "test", panopticon_id: @artefact.id)
     boss_user.assign(publication, worker_user)


### PR DESCRIPTION
Adds a uniqueness constraint on `User` `uid` at the data~~base~~ store level.
