### PR TITLE
Validate smart quotes as normal quotes in links

### DIFF
--- a/app/validators/link_validator.rb
+++ b/app/validators/link_validator.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class LinkValidator < ActiveModel::Validator
   def validate(record)
     record.class::GOVSPEAK_FIELDS.each do |govspeak_field_name|
@@ -21,7 +23,7 @@ class LinkValidator < ActiveModel::Validator
 
     errors = Set.new
 
-    string.scan(link_regex) do |match|
+    string.gsub(/(“|”)+/, '"').scan(link_regex) do |match|
 
       if match[0] !~ %r{^(?:https?://|mailto:|/)}
         errors << 'Internal links must start with a forward slash eg [link text](/link-destination). External links must start with http://, https://, or mailto: eg [external link text](https://www.google.co.uk).'

--- a/test/validators/link_validator_test.rb
+++ b/test/validators/link_validator_test.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'test_helper'
 
 class LinkValidatorTest < ActiveSupport::TestCase
@@ -35,6 +37,12 @@ class LinkValidatorTest < ActiveSupport::TestCase
 
     should "not contain hover text" do
       doc = Dummy.new(body: 'abc [foobar](http://foobar.com "hover")')
+      assert doc.invalid?
+      assert_includes doc.errors.keys, :body
+    end
+
+    should "validate smart quotes as normal quotes" do
+      doc = Dummy.new(body: %q<abc [foobar](http://foobar.com “hover”)>)
       assert doc.invalid?
       assert_includes doc.errors.keys, :body
     end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8852

the `LinkValidator` regex doesn't validate correctly when the link contains smart quotes. corrected that so that we can update travel advice publisher to use the latest version of govuk_content_models.
