### PR TITLE
Version to 26.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 26.3.0
+- Corrected to return public timestamp of first edition when no major changes
+
 ## 26.2.0
 - Adds `reviewer` `String` field to `Edition` class.
 

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "26.2.0"
+  VERSION = "26.3.0"
 end


### PR DESCRIPTION
When no major changes have been made to an edition, public_updated_at should return the public timestamp of the first edition not the latest edition
