### PR TITLE
Release 27.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
-## 26.3.0
+## 27.0.0
+
 - Corrected to return public timestamp of first edition when no major changes
+- Adds a unique index on the `uid` field for a `User`. (breaking change)
+
+## 26.3.0 (yanked)
+- Corrected to return public timestamp of first edition when no major changes
+- Yanked due to the unintended inclusion of a breaking change.
 
 ## 26.2.0
 - Adds `reviewer` `String` field to `Edition` class.

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "26.3.0"
+  VERSION = "27.0.0"
 end


### PR DESCRIPTION
This releases gem version 27.0.0, which includes a breaking change to the `User` model.

As the breaking change was inadvertently included in the previous minor update, we yanked the release and are re-issuing it as a major version bump.

Relates to #265, #266 and #268.
