### PR TITLE
Remove minutes to complete and ‘uses government gateway’

### DIFF
--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -7,14 +7,11 @@ class LocalTransactionEdition < Edition
   field :introduction, type: String
   field :more_information, type: String
   field :need_to_know, type: String
-  field :minutes_to_complete, type: String
-  field :uses_government_gateway, type: Boolean
 
   GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:introduction, :more_information, :need_to_know]
 
   @fields_to_clone = [
-    :lgsl_code, :introduction, :more_information,
-    :minutes_to_complete, :need_to_know
+    :lgsl_code, :introduction, :more_information, :need_to_know
   ]
 
   validate :valid_lgsl_code

--- a/app/models/place_edition.rb
+++ b/app/models/place_edition.rb
@@ -5,8 +5,6 @@ class PlaceEdition < Edition
   field :more_information, type: String
   field :need_to_know, type: String
   field :place_type, type: String
-  field :minutes_to_complete, type: String
-  field :uses_government_gateway, type: Boolean
 
   GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:introduction, :more_information, :need_to_know]
 

--- a/app/models/transaction_edition.rb
+++ b/app/models/transaction_edition.rb
@@ -7,14 +7,11 @@ class TransactionEdition < Edition
   field :more_information, type: String
   field :need_to_know, type: String
   field :alternate_methods, type: String
-  field :minutes_to_complete, type: String
-  field :uses_government_gateway, type: Boolean
 
   GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:introduction, :more_information, :alternate_methods, :need_to_know]
 
   @fields_to_clone = [:introduction, :will_continue_on, :link,
                       :more_information, :alternate_methods,
-                      :minutes_to_complete, :uses_government_gateway,
                       :need_to_know]
 
   def indexable_content


### PR DESCRIPTION
Remove from place, local transaction and transaction formats.
These fields are not used and can be accommodated by the govspeak ‘need to know’ field.

Part of https://www.agileplannerapp.com/boards/173808/cards/8894
