### PR TITLE
Version 28.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 28.0.0
+
+- Removes `uses_government_gateway` and `minutes_to_complete` fields from
+  `Edition` class
+
 ## 27.2.0
 
 - Adds `unassign` instance method for `User` class which allows users to

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "27.2.0"
+  VERSION = "28.0.0"
 end


### PR DESCRIPTION
Removes `uses_government_gateway` and `minutes_to_complete` fields from `Edition` class
