### PR TITLE
Define GOVSPEAK_FIELDS only on models that have it

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -41,9 +41,6 @@ class Action
   field :customised_message, type: String
   field :created_at,         type: DateTime, default: lambda { Time.zone.now }
 
-  GOVSPEAK_FIELDS = []
-  validates_with SafeHtml
-
   def container_class_name(edition)
     edition.container.class.name.underscore.humanize
   end

--- a/app/models/answer_edition.rb
+++ b/app/models/answer_edition.rb
@@ -3,7 +3,7 @@ require "edition"
 class AnswerEdition < Edition
   field :body, type: String
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body]
+  GOVSPEAK_FIELDS = [:body]
 
   @fields_to_clone = [:body]
 

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -61,10 +61,6 @@ class Artefact
 
   scope :not_archived, where(:state.nin => ["archived"])
 
-  GOVSPEAK_FIELDS = []
-
-  validates_with SafeHtml
-
   MAXIMUM_RELATED_ITEMS = 8
 
   FORMATS_BY_DEFAULT_OWNING_APP = {

--- a/app/models/artefact_action.rb
+++ b/app/models/artefact_action.rb
@@ -7,11 +7,7 @@ class ArtefactAction
   field "action_type", type: String
   field "snapshot", type: Hash
 
-  GOVSPEAK_FIELDS = []
-
   embedded_in :artefact
-
-  validates_with SafeHtml
 
   # Ideally we would like to use the UID field here, since that will be the
   # same across all applications, but Mongoid doesn't yet support using a

--- a/app/models/artefact_external_link.rb
+++ b/app/models/artefact_external_link.rb
@@ -4,11 +4,7 @@ class ArtefactExternalLink
   field "title", type: String
   field "url", type: String
 
-  GOVSPEAK_FIELDS = []
-
   embedded_in :artefact
-
-  validates_with SafeHtml
 
   validates_presence_of :title
   validates :url, :presence => true, :format => { :with => URI::regexp(%w{http https}) }

--- a/app/models/business_support_edition.rb
+++ b/app/models/business_support_edition.rb
@@ -30,7 +30,7 @@ class BusinessSupportEdition < Edition
   field :end_date,        type: Date
   field :areas,           type: Array, default: []
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body, :eligibility, :evaluation, :additional_information]
+  GOVSPEAK_FIELDS = [:body, :eligibility, :evaluation, :additional_information]
 
   validate :scheme_dates
   validate :min_must_be_less_than_max

--- a/app/models/campaign_edition.rb
+++ b/app/models/campaign_edition.rb
@@ -12,7 +12,8 @@ class CampaignEdition < Edition
 
   attaches :large_image, :medium_image, :small_image
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body]
+  GOVSPEAK_FIELDS = [:body]
+
   @fields_to_clone = [
     :body, :large_image_id, :medium_image_id, :small_image_id,
     :organisation_formatted_name, :organisation_url, :organisation_brand_colour, :organisation_crest

--- a/app/models/completed_transaction_edition.rb
+++ b/app/models/completed_transaction_edition.rb
@@ -3,7 +3,7 @@ require "edition"
 class CompletedTransactionEdition < Edition
   field :body, type: String
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body]
+  GOVSPEAK_FIELDS = [:body]
 
   @fields_to_clone = [:body]
 

--- a/app/models/curated_list.rb
+++ b/app/models/curated_list.rb
@@ -13,10 +13,7 @@ class CuratedList
 
   index "slug"
 
-  GOVSPEAK_FIELDS = []
-
   validates :slug, presence: true, uniqueness: true, slug: true
-  validates_with SafeHtml
 
   def self.find_by_slug(slug)
     where(slug: slug).first

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -34,8 +34,6 @@ class Edition
   field :change_note,          type: String
   field :review_requested_at,  type: DateTime
 
-  GOVSPEAK_FIELDS = []
-
   belongs_to :assigned_to, class_name: "User"
 
   # state_machine comes from Workflow

--- a/app/models/guide_edition.rb
+++ b/app/models/guide_edition.rb
@@ -7,6 +7,7 @@ class GuideEdition < Edition
   field :video_url,     type: String
   field :video_summary, type: String
 
+  GOVSPEAK_FIELDS = []
   @fields_to_clone = [:video_url, :video_summary]
 
   def has_video?

--- a/app/models/help_page_edition.rb
+++ b/app/models/help_page_edition.rb
@@ -3,7 +3,7 @@ require "edition"
 class HelpPageEdition < Edition
   field :body, type: String
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body]
+  GOVSPEAK_FIELDS = [:body]
 
   @fields_to_clone = [:body]
 

--- a/app/models/licence_edition.rb
+++ b/app/models/licence_edition.rb
@@ -8,12 +8,12 @@ class LicenceEdition < Edition
   field :will_continue_on, :type => String
   field :continuation_link, :type => String
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:licence_overview]
+  GOVSPEAK_FIELDS = [:licence_overview]
 
   validates :licence_identifier, :presence => true
   validate :licence_identifier_unique
   validates_format_of :continuation_link, :with => URI::regexp(%w(http https)), :allow_blank => true
-  
+
   @fields_to_clone = [:licence_identifier, :licence_short_description,
                       :licence_overview, :will_continue_on, :continuation_link]
 

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -16,11 +16,8 @@ class LocalAuthority
   field :contact_phone,      type: String
   field :contact_email,      type: String
 
-  GOVSPEAK_FIELDS = []
-
   validates_uniqueness_of :snac
   validates_presence_of   :snac, :local_directgov_id, :name, :tier
-  validates_with SafeHtml
 
   scope :for_snacs, ->(snacs) { any_in(snac: snacs) }
 

--- a/app/models/local_interaction.rb
+++ b/app/models/local_interaction.rb
@@ -10,11 +10,8 @@ class LocalInteraction
   field :lgil_code, type: Integer
   field :url,       type: String
 
-  GOVSPEAK_FIELDS = []
-
   embedded_in :local_authority
 
   validates_presence_of :url, :lgil_code, :lgsl_code
   validates_uniqueness_of :lgil_code, :scope => :lgsl_code
-  validates_with SafeHtml
 end

--- a/app/models/local_service.rb
+++ b/app/models/local_service.rb
@@ -9,14 +9,11 @@ class LocalService
   field :lgsl_code,      type: Integer
   field :providing_tier, type: Array
 
-  GOVSPEAK_FIELDS = []
-
   validates_presence_of :lgsl_code, :providing_tier
   validates_uniqueness_of :lgsl_code
   validates :providing_tier, inclusion: {
     in: [%w{county unitary}, %w{district unitary}, %w{district unitary county}]
   }
-  validates_with SafeHtml
 
   def self.find_by_lgsl_code(lgsl_code)
     LocalService.where(lgsl_code: lgsl_code).first

--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -8,7 +8,7 @@ class LocalTransactionEdition < Edition
   field :more_information, type: String
   field :need_to_know, type: String
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:introduction, :more_information, :need_to_know]
+  GOVSPEAK_FIELDS = [:introduction, :more_information, :need_to_know]
 
   @fields_to_clone = [
     :lgsl_code, :introduction, :more_information, :need_to_know

--- a/app/models/manual_change_history.rb
+++ b/app/models/manual_change_history.rb
@@ -12,7 +12,4 @@ class ManualChangeHistory
   index "slug", unique: true
 
   validates :slug, uniqueness: true
-  validates_with SafeHtml
-
-  GOVSPEAK_FIELDS = []
 end

--- a/app/models/overview_dashboard.rb
+++ b/app/models/overview_dashboard.rb
@@ -17,8 +17,4 @@ class OverviewDashboard
   field :fact_check,          type: Integer
   field :published,           type: Integer
   field :archived,            type: Integer
-
-  GOVSPEAK_FIELDS = []
-
-  validates_with SafeHtml
 end

--- a/app/models/place_edition.rb
+++ b/app/models/place_edition.rb
@@ -6,7 +6,7 @@ class PlaceEdition < Edition
   field :need_to_know, type: String
   field :place_type, type: String
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:introduction, :more_information, :need_to_know]
+  GOVSPEAK_FIELDS = [:introduction, :more_information, :need_to_know]
 
   @fields_to_clone = [:introduction, :more_information, :place_type, :need_to_know]
 

--- a/app/models/programme_edition.rb
+++ b/app/models/programme_edition.rb
@@ -6,6 +6,7 @@ class ProgrammeEdition < Edition
 
   before_save :setup_default_parts, on: :create
 
+  GOVSPEAK_FIELDS = []
   @fields_to_clone = []
 
   DEFAULT_PARTS = [

--- a/app/models/rendered_manual.rb
+++ b/app/models/rendered_manual.rb
@@ -13,8 +13,5 @@ class RenderedManual
 
   index "slug", unique: true
 
-  GOVSPEAK_FIELDS = []
-
-  validates_with SafeHtml
   validates_uniqueness_of :slug
 end

--- a/app/models/rendered_specialist_document.rb
+++ b/app/models/rendered_specialist_document.rb
@@ -15,8 +15,5 @@ class RenderedSpecialistDocument
 
   index "slug", unique: true
 
-  GOVSPEAK_FIELDS = []
-
   validates :slug, uniqueness: true
-  validates_with SafeHtml
 end

--- a/app/models/simple_smart_answer_edition.rb
+++ b/app/models/simple_smart_answer_edition.rb
@@ -11,7 +11,8 @@ class SimpleSmartAnswerEdition < Edition
 
   accepts_nested_attributes_for :nodes, allow_destroy: true
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body]
+  GOVSPEAK_FIELDS = [:body]
+
   @fields_to_clone = [:body]
 
   def whole_body

--- a/app/models/simple_smart_answer_edition/node.rb
+++ b/app/models/simple_smart_answer_edition/node.rb
@@ -28,7 +28,6 @@ class SimpleSmartAnswerEdition < Edition
     validates :slug, :presence => true, :format => {:with => /\A[a-z0-9-]+\z/}
 
     validate :outcomes_have_no_options
-
     validates_with SafeHtml
 
     private

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -13,7 +13,6 @@ class Tag
   field :parent_id,         type: String
   field :state,             type: String, default: 'draft'
 
-  GOVSPEAK_FIELDS = []
   STATES = ['draft', 'live']
 
   index :tag_id
@@ -23,7 +22,6 @@ class Tag
   validates_presence_of :tag_id, :title, :tag_type
   validates_uniqueness_of :tag_id, scope: :tag_type
   validates_with TagIdValidator
-  validates_with SafeHtml
 
   attr_protected :state
 

--- a/app/models/transaction_edition.rb
+++ b/app/models/transaction_edition.rb
@@ -8,7 +8,7 @@ class TransactionEdition < Edition
   field :need_to_know, type: String
   field :alternate_methods, type: String
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:introduction, :more_information, :alternate_methods, :need_to_know]
+  GOVSPEAK_FIELDS = [:introduction, :more_information, :alternate_methods, :need_to_know]
 
   @fields_to_clone = [:introduction, :will_continue_on, :link,
                       :more_information, :alternate_methods,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,8 +26,6 @@ class User
   index "uid", unique: true
   index "disabled"
 
-  GOVSPEAK_FIELDS = []
-
   # Setup accessible (or protected) attributes for your model
   attr_accessible :email, :name, :uid
   attr_accessible :email, :name, :uid, :permissions, as: :oauth
@@ -35,8 +33,6 @@ class User
   scope :alphabetized, order_by(name: :asc)
   scope :enabled, any_of({ :disabled.exists => false },
                          { :disabled.in => [false, nil] })
-
-  validates_with SafeHtml
 
   def to_s
     name || email || ""

--- a/app/models/video_edition.rb
+++ b/app/models/video_edition.rb
@@ -8,7 +8,7 @@ class VideoEdition < Edition
   field :video_summary, type: String
   field :body,          type: String
 
-  GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:body]
+  GOVSPEAK_FIELDS = [:body]
 
   @fields_to_clone = [:video_url, :video_summary, :body]
 

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -286,11 +286,11 @@ class ArtefactTest < ActiveSupport::TestCase
     parent = Artefact.create!(slug: "parent", name: "Parent", kind: "guide", owning_app: "x")
 
     a = Artefact.create!(slug: "a", name: "has no published editions", kind: "guide", owning_app: "publisher")
-    Edition.create!(panopticon_id: a.id, title: "Unpublished", state: "draft")
+    GuideEdition.create!(panopticon_id: a.id, title: "Unpublished", state: "draft")
     parent.related_artefacts << a
 
     b = Artefact.create!(slug: "b", name: "has a published edition", kind: "guide", owning_app: "publisher")
-    Edition.create!(panopticon_id: b.id, title: "Published", state: "published")
+    GuideEdition.create!(panopticon_id: b.id, title: "Published", state: "published")
     parent.related_artefacts << b
 
     c = Artefact.create!(slug: "c", name: "not a publisher artefact", kind: "place", owning_app: "x")

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -110,30 +110,30 @@ class EditionTest < ActiveSupport::TestCase
 
   context "change note" do
     should "be a minor change by default" do
-      refute Edition.new.major_change
+      refute AnswerEdition.new.major_change
     end
     should "not be valid for major changes with a blank change note" do
-      edition = Edition.new(major_change: true, change_note: "")
+      edition = AnswerEdition.new(major_change: true, change_note: "")
       refute edition.valid?
       assert edition.errors.has_key?(:change_note)
     end
     should "be valid for major changes with a change note" do
-      edition = Edition.new(title: "Edition", version_number: 1, panopticon_id: 123, major_change: true, change_note: "Changed")
+      edition = AnswerEdition.new(title: "Edition", version_number: 1, panopticon_id: 123, major_change: true, change_note: "Changed")
       assert edition.valid?
     end
     should "be valid when blank for minor changes" do
-      edition = Edition.new(title: "Edition", version_number: 1, panopticon_id: 123, change_note: "")
+      edition = AnswerEdition.new(title: "Edition", version_number: 1, panopticon_id: 123, change_note: "")
       assert edition.valid?
     end
     should "be valid when populated for minor changes" do
-      edition = Edition.new(title: "Edition", version_number: 1, panopticon_id: 123, change_note: "Changed")
+      edition = AnswerEdition.new(title: "Edition", version_number: 1, panopticon_id: 123, change_note: "Changed")
       assert edition.valid?
     end
   end
 
   test "reviewer cannot be the assignee" do
     user = FactoryGirl.create(:user)
-    edition = Edition.new(title: "Edition", version_number: 1, panopticon_id: 123,
+    edition = AnswerEdition.new(title: "Edition", version_number: 1, panopticon_id: 123,
                           state: "in_review", review_requested_at: Time.zone.now, assigned_to: user)
     edition.reviewer = user.name
     refute edition.valid?

--- a/test/models/prerendered_entity_tests.rb
+++ b/test/models/prerendered_entity_tests.rb
@@ -10,7 +10,7 @@ module PrerenderedEntityTests
   end
 
   def test_has_no_govspeak_fields
-    assert_equal [], model_class::GOVSPEAK_FIELDS
+    refute model_class.const_defined?(:GOVSPEAK_FIELDS)
   end
 
   def test_create_or_update_by_slug

--- a/test/validators/safe_html_validator_test.rb
+++ b/test/validators/safe_html_validator_test.rb
@@ -65,7 +65,7 @@ class SafeHtmlTest < ActiveSupport::TestCase
       assert dummy.invalid?
     end
 
-    should "all models should use this validator" do
+    should "all models that have govspeak fields should use this validator" do
       models_dir = File.expand_path("../../app/models/*", File.dirname(__FILE__))
 
       classes = Dir[models_dir]
@@ -73,7 +73,7 @@ class SafeHtmlTest < ActiveSupport::TestCase
           File.basename(file, ".rb").camelize.constantize
         }
         .select { |klass|
-          klass.included_modules.include?(Mongoid::Document)
+          klass.included_modules.include?(Mongoid::Document) && klass.const_defined?(:GOVSPEAK_FIELDS)
         }
         .each { |klass|
           assert_includes klass.validators.map(&:class), SafeHtml, "#{klass} must be validated with SafeHtml"


### PR DESCRIPTION
[this safe_html_validator_test](https://github.com/alphagov/govuk_content_models/blob/master/test/validators/safe_html_validator_test.rb#L68-L81) mandates all models to validate using the `SafeHtml` validator irrespective of whether they have any govspeak or not. this in turn requires all models to define `GOVSPEAK_FIELDS`.

i've updated the test to only validate that models that define `GOVSPEAK_FIELDS` validate using `SafeHtml`. models have better reason to define `GOVSPEAK_FIELDS` in that it helps [content api identify](https://github.com/alphagov/govuk_content_api/blob/2014fda929ca5aa7e717040633892943eaa7b110/lib/presenters/artefact_presenter.rb#L113-L117) which fields need to be rendered as govspeak, so defining it is not likely to get missed.
