### PR TITLE
Add downtime to artefacts

### DIFF
--- a/app/models/downtime.rb
+++ b/app/models/downtime.rb
@@ -6,6 +6,8 @@ class Downtime
   field :start_time, type: DateTime
   field :end_time, type: DateTime
 
+  belongs_to :artefact
+
   validates_presence_of :message, :start_time, :end_time, :artefact
   validate :end_time_is_in_future, on: :create
   validate :start_time_precedes_end_time

--- a/app/models/downtime.rb
+++ b/app/models/downtime.rb
@@ -1,0 +1,30 @@
+class Downtime
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :message, type: String
+  field :start_time, type: DateTime
+  field :end_time, type: DateTime
+
+  validates_presence_of :message, :start_time, :end_time, :artefact
+  validate :end_time_is_in_future, on: :create
+  validate :start_time_precedes_end_time
+
+  def self.for(artefact)
+    where(artefact_id: artefact.id).first
+  end
+
+  def publicise?
+    Time.zone.now.between?(start_time.to_date - 1, end_time) # starting at midnight a day before start time
+  end
+
+  private
+
+  def end_time_is_in_future
+    errors.add(:end_time, "must be in the future") if end_time && ! end_time.future?
+  end
+
+  def start_time_precedes_end_time
+    errors.add(:start_time, "must be earlier than end time") if start_time && end_time && start_time >= end_time
+  end
+end

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -19,6 +19,12 @@ FactoryGirl.define do
     disabled true
   end
 
+  factory :downtime do
+    message "This service will be unavailable from 3pm to 6pm tomorrow"
+    start_time (Date.today + 1).to_time + (15 * 60 * 60)
+    end_time (Date.today + 1).to_time + (18 * 60 * 60)
+  end
+
   factory :tag do
     sequence(:tag_id) { |n| "crime-and-justice-#{n}" }
     sequence(:title) { |n| "The title #{n}" }

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -23,6 +23,7 @@ FactoryGirl.define do
     message "This service will be unavailable from 3pm to 6pm tomorrow"
     start_time (Date.today + 1).to_time + (15 * 60 * 60)
     end_time (Date.today + 1).to_time + (18 * 60 * 60)
+    artefact
   end
 
   factory :tag do

--- a/test/models/downtime_test.rb
+++ b/test/models/downtime_test.rb
@@ -16,6 +16,13 @@ class DowntimeTest < ActiveSupport::TestCase
       assert_includes downtime.errors[:end_time], "can't be blank"
     end
 
+    should "validate presence of artefact" do
+      downtime = FactoryGirl.build(:downtime, artefact: nil)
+
+      refute downtime.valid?
+      assert_includes downtime.errors[:artefact], "can't be blank"
+    end
+
     should "validate end time is in future" do
       downtime = FactoryGirl.build(:downtime, end_time: Date.today - 1)
 
@@ -35,6 +42,43 @@ class DowntimeTest < ActiveSupport::TestCase
 
       refute downtime.valid?
       assert_includes downtime.errors[:start_time], "must be earlier than end time"
+    end
+  end
+
+  context "for an artefact" do
+    should "be returned if found" do
+      downtime = FactoryGirl.create(:downtime)
+      assert_equal downtime, Downtime.for(downtime.artefact)
+    end
+
+    should "be nil if not found" do
+      assert_nil Downtime.for(FactoryGirl.build(:artefact))
+    end
+  end
+
+  context "publicising downtime" do
+    should "start at midnight a day before it is scheduled" do
+      Timecop.freeze(Date.today) do # beginnning of today
+        downtime = FactoryGirl.build(:downtime)
+
+        downtime.start_time = (Date.today + 1).to_time + (3 * 60 * 60) # 3am tomorrow
+        assert downtime.publicise?
+
+        downtime.start_time = Date.today.to_time + (21 * 60 * 60) # 9pm today
+        assert downtime.publicise?
+
+        downtime.start_time = Date.today + 2 # day after tomorrow
+        refute downtime.publicise?
+      end
+    end
+
+    should "stop after scheduled end time" do
+      Timecop.freeze(Time.zone.now + 10) do
+        downtime = FactoryGirl.build(:downtime)
+
+        downtime.end_time = Time.zone.now
+        refute downtime.publicise?
+      end
     end
   end
 

--- a/test/models/downtime_test.rb
+++ b/test/models/downtime_test.rb
@@ -2,6 +2,13 @@ require "test_helper"
 
 class DowntimeTest < ActiveSupport::TestCase
   context "validations" do
+    should "validate presence of message" do
+      downtime = FactoryGirl.build(:downtime, message: nil)
+
+      refute downtime.valid?
+      assert_includes downtime.errors[:message], "can't be blank"
+    end
+
     should "validate presence of start time" do
       downtime = FactoryGirl.build(:downtime, start_time: nil)
 

--- a/test/models/downtime_test.rb
+++ b/test/models/downtime_test.rb
@@ -89,40 +89,4 @@ class DowntimeTest < ActiveSupport::TestCase
     end
   end
 
-  context "for an artefact" do
-    should "be returned if found" do
-      downtime = FactoryGirl.create(:downtime)
-      assert_equal downtime, Downtime.for(downtime.artefact)
-    end
-
-    should "be nil if not found" do
-      assert_nil Downtime.for(FactoryGirl.build(:artefact))
-    end
-  end
-
-  context "publicising downtime" do
-    should "start at midnight a day before it is scheduled" do
-      Timecop.freeze(Date.today) do # beginnning of today
-        downtime = FactoryGirl.build(:downtime)
-
-        downtime.start_time = (Date.today + 1).to_time + (3 * 60 * 60) # 3am tomorrow
-        assert downtime.publicise?
-
-        downtime.start_time = Date.today.to_time + (21 * 60 * 60) # 9pm today
-        assert downtime.publicise?
-
-        downtime.start_time = Date.today + 2 # day after tomorrow
-        refute downtime.publicise?
-      end
-    end
-
-    should "stop after scheduled end time" do
-      Timecop.freeze(Time.zone.now + 10) do
-        downtime = FactoryGirl.build(:downtime)
-
-        downtime.end_time = Time.zone.now
-        refute downtime.publicise?
-      end
-    end
-  end
 end

--- a/test/models/downtime_test.rb
+++ b/test/models/downtime_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class DowntimeTest < ActiveSupport::TestCase
+  context "validations" do
+    should "validate presence of start time" do
+      downtime = FactoryGirl.build(:downtime, start_time: nil)
+
+      refute downtime.valid?
+      assert_includes downtime.errors[:start_time], "can't be blank"
+    end
+
+    should "validate presence of end time" do
+      downtime = FactoryGirl.build(:downtime, end_time: nil)
+
+      refute downtime.valid?
+      assert_includes downtime.errors[:end_time], "can't be blank"
+    end
+
+    should "validate end time is in future" do
+      downtime = FactoryGirl.build(:downtime, end_time: Date.today - 1)
+
+      refute downtime.valid?
+      assert_includes downtime.errors[:end_time], 'must be in the future'
+    end
+
+    should "validate end time is in future only on create" do
+      downtime = FactoryGirl.create(:downtime)
+      downtime.assign_attributes(start_time: Date.today - 3, end_time: Date.today - 1)
+
+      assert downtime.valid?
+    end
+
+    should "validate start time is earlier than end time" do
+      downtime = FactoryGirl.build(:downtime, start_time: Date.today + 2, end_time: Date.today + 1)
+
+      refute downtime.valid?
+      assert_includes downtime.errors[:start_time], "must be earlier than end time"
+    end
+  end
+
+  context "for an artefact" do
+    should "be returned if found" do
+      downtime = FactoryGirl.create(:downtime)
+      assert_equal downtime, Downtime.for(downtime.artefact)
+    end
+
+    should "be nil if not found" do
+      assert_nil Downtime.for(FactoryGirl.build(:artefact))
+    end
+  end
+
+  context "publicising downtime" do
+    should "start at midnight a day before it is scheduled" do
+      Timecop.freeze(Date.today) do # beginnning of today
+        downtime = FactoryGirl.build(:downtime)
+
+        downtime.start_time = (Date.today + 1).to_time + (3 * 60 * 60) # 3am tomorrow
+        assert downtime.publicise?
+
+        downtime.start_time = Date.today.to_time + (21 * 60 * 60) # 9pm today
+        assert downtime.publicise?
+
+        downtime.start_time = Date.today + 2 # day after tomorrow
+        refute downtime.publicise?
+      end
+    end
+
+    should "stop after scheduled end time" do
+      Timecop.freeze(Time.zone.now + 10) do
+        downtime = FactoryGirl.build(:downtime)
+
+        downtime.end_time = Time.zone.now
+        refute downtime.publicise?
+      end
+    end
+  end
+end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8805

As a content designer
I want a better way to indicate on transaction start pages when a service is down for planned maintenance
So that I don't have to re-edition multiple pages and push these through workflow, then repeat the process again once the downtime is over

related:
https://github.com/alphagov/publisher/pull/340
https://github.com/alphagov/govuk_content_api/pull/209
https://github.com/alphagov/frontend/pull/709