### PR TITLE
Skip markdown link validation for archived editions.

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -55,7 +55,7 @@ class Edition
   validates :version_number, presence: true, uniqueness: {scope: :panopticon_id}
   validates :panopticon_id, presence: true
   validates_with SafeHtml
-  validates_with LinkValidator, on: :update
+  validates_with LinkValidator, on: :update, unless: :archived?
   validates_with TopicValidator, BrowsePageValidator, ReviewerValidator
   validates_presence_of :change_note, if: :major_change
 

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -106,6 +106,14 @@ class EditionTest < ActiveSupport::TestCase
       refute edition.valid?
       assert_include edition.errors.full_messages, %q<Body ["Don't include hover text in links. Delete the text in quotation marks eg \\"This appears when you hover over the link.\\""]>
     end
+
+    should "allow archiving an edition with invalid links" do
+      edition = FactoryGirl.create(:answer_edition, state: 'published', body: 'abc [foobar](http://foobar.com "hover")')
+
+      assert_difference 'AnswerEdition.archived.count', 1 do
+        edition.archive!
+      end
+    end
   end
 
   context "change note" do


### PR DESCRIPTION
This is currently preventing some published editions from being archived
due to them having content that predates this check.