### PR TITLE
Clearer need ID validation error.

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -393,7 +393,7 @@ class Artefact
 
     # http://api.rubyonrails.org/classes/ActiveModel/Dirty.html
     new_need_ids = need_ids_was.blank? ? need_ids : need_ids - need_ids_was
-    errors.add(:need_ids, "must be six-digit integers") if new_need_ids.any? {|need_id| need_id !~ /\A\d{6}\z/ }
+    errors.add(:need_ids, "must be six-digit integer strings") if new_need_ids.any? {|need_id| need_id !~ /\A\d{6}\z/ }
   end
 
   def valid_url_path?(path)

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -118,7 +118,7 @@ class ArtefactTest < ActiveSupport::TestCase
       artefact = FactoryGirl.build(:artefact, need_ids: ["B1231"])
 
       refute artefact.valid?
-      assert_includes artefact.errors[:need_ids], "must be six-digit integers"
+      assert_includes artefact.errors[:need_ids], "must be six-digit integer strings"
     end
 
     should "not validate need ids that were migrated from the singular need_id field" do


### PR DESCRIPTION
The validation requires 6-digit integer strings,
not integers.