### PR TITLE
Add index for `created_at` on edition.

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -65,6 +65,7 @@ class Edition
   index "assigned_to_id"
   index [["panopticon_id", Mongo::ASCENDING], ["version_number", Mongo::ASCENDING]], :unique => true
   index "state"
+  index "created_at"
   index "updated_at"
 
   class << self; attr_accessor :fields_to_clone end


### PR DESCRIPTION
Needed for sorting in a Publisher report.