### PR TITLE
Include part errors in edition errors

### DIFF
--- a/app/models/parted.rb
+++ b/app/models/parted.rb
@@ -5,6 +5,7 @@ module Parted
     klass.embeds_many :parts
     klass.accepts_nested_attributes_for :parts, allow_destroy: true,
       reject_if: proc { |attrs| attrs["title"].blank? and attrs["body"].blank? }
+    klass.after_validation :merge_embedded_parts_errors
   end
 
   def build_clone(edition_class=nil)
@@ -28,5 +29,20 @@ module Parted
 
   def whole_body
     self.parts.map {|i| %Q{\# #{i.title}\n\n#{i.body}} }.join("\n\n")
+  end
+
+  private
+
+  def merge_embedded_parts_errors
+    return if parts.empty?
+
+    if errors.delete(:parts) == ["is invalid"]
+      index = -1
+      parts_errors = parts.inject({}) do |result, part|
+        result[index += 1] = part.errors.messages
+        result
+      end
+      errors.add(:parts, parts_errors)
+    end
   end
 end

--- a/app/models/parted.rb
+++ b/app/models/parted.rb
@@ -37,9 +37,8 @@ module Parted
     return if parts.empty?
 
     if errors.delete(:parts) == ["is invalid"]
-      index = -1
       parts_errors = parts.inject({}) do |result, part|
-        result[index += 1] = part.errors.messages
+        result["#{part._id}:#{part.order}"] = part.errors.messages if part.errors.present?
         result
       end
       errors.add(:parts, parts_errors)

--- a/app/validators/link_validator.rb
+++ b/app/validators/link_validator.rb
@@ -7,7 +7,7 @@ class LinkValidator < ActiveModel::Validator
       next if govspeak_field_value.blank?
 
       messages = errors(govspeak_field_value)
-      record.errors[govspeak_field_name] << messages if messages
+      record.errors[govspeak_field_name] << messages unless messages.blank?
     end
   end
 

--- a/test/models/parted_test.rb
+++ b/test/models/parted_test.rb
@@ -5,21 +5,14 @@ require "test_helper"
 class PartedTest < ActiveSupport::TestCase
   test "should merge part validation errors with parent document's errors" do
     edition = FactoryGirl.create(:guide_edition)
-    edition.parts.build(title: "", slug: "overview")
-    edition.parts.build(title: "Prepare for your appointment", slug: "")
+    edition.parts.build(_id: '54c10d4d759b743528000010', order: '1', title: "", slug: "overview")
+    edition.parts.build(_id: '54c10d4d759b743528000011', order: '2', title: "Prepare for your appointment", slug: "")
+    edition.parts.build(_id: '54c10d4d759b743528000012', order: '3', title: "Valid", slug: "valid")
 
     refute edition.valid?
-    assert_equal({title: ["can't be blank"]}, edition.errors[:parts][0][0])
-    assert_equal({slug: ["can't be blank", "is invalid"]}, edition.errors[:parts][0][1])
-  end
 
-  test "should merge parts without validation errors when even one part has an error" do
-    edition = FactoryGirl.create(:guide_edition_with_two_parts)
-    edition.parts.build(title: "Overview", slug: "")
-
-    refute edition.valid?
-    assert_equal({}, edition.errors[:parts][0][0])
-    assert_equal({}, edition.errors[:parts][0][1])
-    assert_equal({slug: ["can't be blank", "is invalid"]}, edition.errors[:parts][0][2])
+    assert_equal({title: ["can't be blank"]}, edition.errors[:parts][0]['54c10d4d759b743528000010:1'])
+    assert_equal({slug: ["can't be blank", "is invalid"]}, edition.errors[:parts][0]['54c10d4d759b743528000011:2'])
+    assert_equal 2, edition.errors[:parts][0].length
   end
 end

--- a/test/models/parted_test.rb
+++ b/test/models/parted_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+# require "edition"
+# require "parted"
+
+class PartedTest < ActiveSupport::TestCase
+  test "should merge part validation errors with parent document's errors" do
+    edition = FactoryGirl.create(:guide_edition)
+    edition.parts.build(title: "", slug: "overview")
+    edition.parts.build(title: "Prepare for your appointment", slug: "")
+
+    refute edition.valid?
+    assert_equal({title: ["can't be blank"]}, edition.errors[:parts][0][0])
+    assert_equal({slug: ["can't be blank", "is invalid"]}, edition.errors[:parts][0][1])
+  end
+
+  test "should merge parts without validation errors when even one part has an error" do
+    edition = FactoryGirl.create(:guide_edition_with_two_parts)
+    edition.parts.build(title: "Overview", slug: "")
+
+    refute edition.valid?
+    assert_equal({}, edition.errors[:parts][0][0])
+    assert_equal({}, edition.errors[:parts][0][1])
+    assert_equal({slug: ["can't be blank", "is invalid"]}, edition.errors[:parts][0][2])
+  end
+end

--- a/test/validators/link_validator_test.rb
+++ b/test/validators/link_validator_test.rb
@@ -23,6 +23,13 @@ class LinkValidatorTest < ActiveSupport::TestCase
       assert_empty doc.errors
     end
 
+    should "not contain empty array for errors on fields" do
+      doc = Dummy.new(body: "Nothing is invalid")
+
+      assert doc.valid?
+      assert_empty doc.errors[:body]
+    end
+
     should "start with http[s]://, mailto: or /" do
       doc = Dummy.new(body: "abc [external](external.com)")
       assert doc.invalid?


### PR DESCRIPTION
Edition errors return a less useful message 'is invalid'. This change replaces that message with a hash of errors
on embedded objects.

This change is needed to correctly populate errors on a edition form submitted via AJAX. @fofr's working on that: https://github.com/alphagov/publisher/tree/ajax-save

Requires a fix to `LinkValidator` to not include blank errors. Errors on a Govspeak field like `body` returns `[[]]` due to an incomplete guard condition.