### PR TITLE
Show clash between primary topic and additional topic as an error against a field

### DIFF
--- a/app/validators/topic_validator.rb
+++ b/app/validators/topic_validator.rb
@@ -7,6 +7,7 @@ class TopicValidator < ActiveModel::Validator
 
       if additional_topics.include?(record.primary_topic)
         record.errors.add(:base, "You can't have the primary topic set as an additional topic")
+        record.errors.add(:additional_topics, "can't have the primary topic set as an additional topic")
       end
     end
   end


### PR DESCRIPTION
Rather than showing the error at the top of the page, show it next to the additional_topic field itself. This matches the duplicate topic error above it.

This makes it easier to spot and fix the tagging problem when saving an edition using ajax. Being worked on as part of https://www.agileplannerapp.com/boards/173808/cards/9007 and https://github.com/alphagov/publisher/tree/ajax-save