### PR TITLE
Add countryside stewardship grant

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -82,6 +82,7 @@ class Artefact
     "travel-advice-publisher" => ["travel-advice"],
     "specialist-publisher"    => ["aaib_report",
                                   "cma_case",
+                                  "countryside_stewardship_grant",
                                   "drug_safety_update",
                                   "international_development_fund",
                                   "maib_report",


### PR DESCRIPTION
This format is published from Specialist Publisher initially just by DEFRA editors and will be listed as a Finder. [Ticket](https://trello.com/c/gZoWid5B/523-finder-countryside-stewardship-grants).