### PR TITLE
Add european_structural_investment_fund artefact

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -83,6 +83,7 @@ class Artefact
     "specialist-publisher"    => ["aaib_report",
                                   "cma_case",
                                   "drug_safety_update",
+                                  "european_structural_investment_fund",
                                   "international_development_fund",
                                   "maib_report",
                                   "manual",


### PR DESCRIPTION
Add support for artefacts with a `kind` of `european_structural_investment_fund`, to be published from Specialist Publisher.

See https://github.com/alphagov/specialist-publisher/pull/411