### PR TITLE
Allow optional content on completed transaction pg

### DIFF
--- a/app/models/completed_transaction_edition.rb
+++ b/app/models/completed_transaction_edition.rb
@@ -1,6 +1,8 @@
 require "edition"
 
 class CompletedTransactionEdition < Edition
+  include PresentationToggles
+
   field :body, type: String
 
   GOVSPEAK_FIELDS = [:body]

--- a/lib/govuk_content_models.rb
+++ b/lib/govuk_content_models.rb
@@ -1,6 +1,7 @@
 require "govuk_content_models/version"
 require "mongoid"
 require "mongoid/monkey_patches"
+require "govuk_content_models/presentation_toggles"
 require "govuk_content_models/action_processors"
 
 module GovukContentModels

--- a/lib/govuk_content_models/presentation_toggles.rb
+++ b/lib/govuk_content_models/presentation_toggles.rb
@@ -1,0 +1,39 @@
+module PresentationToggles
+  extend ActiveSupport::Concern
+
+  included do
+    field :presentation_toggles, type: Hash, default: default_presentation_toggles
+    validates_presence_of :organ_donor_registration_url, if: :promote_organ_donor_registration?
+  end
+
+  def promote_organ_donor_registration=(value)
+    value = value.is_a?(Boolean) ? value : value != '0' # if assigned using a checkbox
+    organ_donor_registration_key['promote_organ_donor_registration'] = value
+  end
+
+  def promote_organ_donor_registration
+    organ_donor_registration_key['promote_organ_donor_registration']
+  end
+  alias_method :promote_organ_donor_registration?, :promote_organ_donor_registration
+
+  def organ_donor_registration_url=(value)
+    organ_donor_registration_key['organ_donor_registration_url'] = value
+  end
+  
+  def organ_donor_registration_url
+    organ_donor_registration_key['organ_donor_registration_url']
+  end
+
+  def organ_donor_registration_key
+    presentation_toggles['organ_donor_registration']
+  end
+
+  module ClassMethods
+    def default_presentation_toggles
+      {
+        'organ_donor_registration' =>
+          { 'promote_organ_donor_registration' => false, 'organ_donor_registration_url' => '' }
+      }
+    end
+  end
+end

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class CompletedTransactionEditionTest < ActiveSupport::TestCase
+  test "controls whether organ donor registration promotion should be displayed on a completed transaction page" do
+    completed_transaction_edition = FactoryGirl.create(:completed_transaction_edition)
+    refute completed_transaction_edition.promote_organ_donor_registration?
+
+    completed_transaction_edition.promote_organ_donor_registration = true
+    completed_transaction_edition.organ_donor_registration_url = "https://www.organdonation.nhs.uk/registration/"
+    completed_transaction_edition.save!
+    assert completed_transaction_edition.reload.promote_organ_donor_registration?
+
+    completed_transaction_edition.promote_organ_donor_registration = false
+    completed_transaction_edition.save!
+    refute completed_transaction_edition.reload.promote_organ_donor_registration?
+  end
+
+  test "stores organ donor registration promotion URL" do
+    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition,
+      promote_organ_donor_registration: true)
+
+    completed_transaction_edition.organ_donor_registration_url = "https://www.organdonation.nhs.uk/registration/"
+    completed_transaction_edition.save!
+
+    assert_equal "https://www.organdonation.nhs.uk/registration/",
+      completed_transaction_edition.reload.organ_donor_registration_url
+  end
+
+  test "invalid if organ_donor_registration_url is not specified when promotion is on" do
+    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition,
+      promote_organ_donor_registration: true, organ_donor_registration_url: "")
+
+    assert completed_transaction_edition.invalid?
+    assert_includes completed_transaction_edition.errors[:organ_donor_registration_url], "can't be blank"
+  end
+end


### PR DESCRIPTION
https://trello.com/c/caDndyIX

As a Service Manager
I want to be able to indicate whether Organ Donor Registration promotion
  should be incorporated into my "Completed transaction" page
so that I can offer users of my service to register for Organ Donation

In order to avoid adding more fields to Edition for such requirements, we're storing information on one Edition field: `presentation_toggles`. It is a Hash containing a boolean which toggles display of this field, and a URL which the promotion links to. Going forward if we have more such requirements, we can dump it into the `presentation_toggles` `Hash`.

`PresentationToggles` includes that new field and adds getter/setter methods on the `Edition`, to make it behave as if `PresentationToggles` are multiple fields on the Edition. This helps with form submissions.