### PR TITLE
Release 28.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 28.6.0
+
+- Add `presentation_toggles` field to CompletedTransactionEdition
+
 ## 28.5.0
 
 - Add `countryside_stewardship_grant` artefact format

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "28.5.0"
+  VERSION = "28.6.0"
 end


### PR DESCRIPTION
https://trello.com/c/oYy2udbc

Add `presentation_toggles` field to CompletedTransactionEdition, to store information to help construct the edition public page. These bits can also be controlled from Publisher.

Releases: https://github.com/alphagov/govuk_content_models/pull/292