### PR TITLE
Keep edition body when converting to simple smart answers

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -210,6 +210,10 @@ class Edition
       new_edition.body = whole_body
     end
 
+    if edition_class == SimpleSmartAnswerEdition && %w(AnswerEdition GuideEdition ProgrammeEdition TransactionEdition).include?(self.class.name)
+      new_edition.body = whole_body
+    end
+
     if edition_class == TransactionEdition and %w(AnswerEdition GuideEdition ProgrammeEdition).include?(self.class.name)
       new_edition.more_information = whole_body
     end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -285,6 +285,27 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal new_edition.more_information, "Test body"
   end
 
+  test "Cloning from AnswerEdition into SimpleSmartAnswerEdition" do
+    edition = FactoryGirl.create(
+      :answer_edition,
+      state: "published",
+      panopticon_id: @artefact.id,
+      version_number: 1,
+      department: "Test dept",
+      overview: "I am a test overview",
+      body: "Test body"
+    )
+    new_edition = edition.build_clone SimpleSmartAnswerEdition
+
+    assert_equal new_edition.class, SimpleSmartAnswerEdition
+    assert_equal new_edition.version_number, 2
+    assert_equal new_edition.panopticon_id, @artefact.id.to_s
+    assert_equal new_edition.state, "draft"
+    assert_equal new_edition.department, "Test dept"
+    assert_equal new_edition.overview, "I am a test overview"
+    assert_equal new_edition.body, "Test body"
+  end
+
   test "Cloning from GuideEdition into TransactionEdition" do
     edition = FactoryGirl.create(
         :guide_edition,


### PR DESCRIPTION
This is to support the Answer => Simple Smart Answer format transition in Publisher.