### PR TITLE
Remove extra time conversion code

### DIFF
--- a/lib/govuk_content_models/action_processors/schedule_for_publishing_processor.rb
+++ b/lib/govuk_content_models/action_processors/schedule_for_publishing_processor.rb
@@ -3,8 +3,8 @@ module GovukContentModels
     class ScheduleForPublishingProcessor < BaseProcessor
 
       def process
-        publish_at = action_attributes.delete(:publish_at).to_time.utc
-        action_attributes.merge!(request_details: { scheduled_time: publish_at })
+        publish_at = action_attributes.delete(:publish_at)
+        action_attributes.merge!(request_details: { scheduled_time: publish_at.utc })
 
         edition.schedule_for_publishing(publish_at)
       end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/91500052

`publish_at` is always assigned as a `DateTime`, so it is not
necessary to convert it to time: http://git.io/ve6ml

`to_time.utc` was probably being done because on the next line
we pass `publish_at` to create a new action which stores it in
a `Hash` field, and `Hash` fields don't support non-UTC times
passed as value:

`ActiveSupport::TimeWithZone is not currently
supported; use a UTC Time instance instead.`

so i've moved the conversion to UTC where we're assigning the
action attribute where it is needed, which ensures that rails
handles the timezone conversion for `publish_at`, as it does
for other `DateTime` fields like Downtime#start_time,
Downtime#end_time.

cc: @fofr 