### PR TITLE
Fix failing DowntimeTest

### DIFF
--- a/app/models/downtime.rb
+++ b/app/models/downtime.rb
@@ -17,7 +17,7 @@ class Downtime
   end
 
   def publicise?
-    Time.zone.now.between?(start_time.to_date - 1, end_time) # starting at midnight a day before start time
+    Time.zone.now.between?(start_time.yesterday.at_midnight, end_time)
   end
 
   private

--- a/test/models/downtime_test.rb
+++ b/test/models/downtime_test.rb
@@ -65,16 +65,17 @@ class DowntimeTest < ActiveSupport::TestCase
 
   context "publicising downtime" do
     should "start at midnight a day before it is scheduled" do
-      Timecop.freeze(Date.today) do # beginnning of today
+      now = Time.zone.parse("2015-01-01")
+      Timecop.freeze(now) do
         downtime = FactoryGirl.build(:downtime)
 
-        downtime.start_time = (Date.today + 1).to_time + (3 * 60 * 60) # 3am tomorrow
+        downtime.start_time = Time.zone.parse("2015-01-02 03:00")
         assert downtime.publicise?
 
-        downtime.start_time = Date.today.to_time + (21 * 60 * 60) # 9pm today
+        downtime.start_time = Time.zone.parse("2015-01-01 21:00")
         assert downtime.publicise?
 
-        downtime.start_time = Date.today + 2 # day after tomorrow
+        downtime.start_time = Time.zone.parse("2015-01-03 00:00")
         refute downtime.publicise?
       end
     end


### PR DESCRIPTION
When I checked the gem out on my local machine and ran the tests I saw the
following failure:

      1) Failure:
    test: publicising downtime should start at midnight a day before it is scheduled. (DowntimeTest) [test/models/downtime_test.rb:72]:
    Failed assertion, no message given.

I assume this was failing when the CI build is not, because the CI build has
not been run for 25 days and new versions of some of the less-constrained
dependent gems are now available and installed by bundler. I assume the
CI build would fail if it were run right now with no changes.

Initially I suspected a new patch version of the `tzinfo` gem, but this turned out
not to be the culprit.

I struggled to work out why the test was failing, because the test was using
instances of `Date` and `Time` whereas `Downtime#publicise?` was operating on
instances of `TimeWithZone`, `DateTime` & `Date`.

So I updated the test to only use instances of `TimeWithZone` and to be more
deterministic and the test started passing!

I've also updated the implementation of `Downtime#publicise?` to use the fluent
time API provided by ActiveSupport in order to make it more readable and obviate
the need for a comment.

I'm afraid I've run out of time to find the underlying problem, but I think these
changes make sense.