### PR TITLE
Relax constraint on govspeak dependency.

### DIFF
--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gds-api-adapters", ">= 10.9.0"
 
   gem.add_dependency "gds-sso",          ">= 10.0.0"
-  gem.add_dependency "govspeak",         "~> 3.1.0"
+  gem.add_dependency "govspeak",         "~> 3.1"
   # Mongoid 2.5.0 supports the newer 1.7.x and 1.8.x Mongo drivers
   gem.add_dependency "mongoid",          "~> 2.5"
   gem.add_dependency "plek"


### PR DESCRIPTION
Given that GDS is in control of govspeak and it's supposed to use semantic
versioning, it ought to be safe to relax this constraint from `~> 3.1.0` to
`~> 3.1`.

I'd like this change because I'm running into a problem running the tests in
panopticon due to an incompatibility between nokogiri and libxml on Mac OS X.
Unfortunately this constraint is preventing me from upgrading nokogiri within
panopticon. In particular I want the version (v3.3.0) of govspeak which includes
[this commit][1].

I see that this change was [attempted][2] some time ago, but then immediately
[reverted][3], so perhaps there are some other problems of which I'm unaware.

[1]: https://github.com/alphagov/govspeak/commit/72e3e4ce0bf7cc2bdf5162a3d5b3b17c6d6ab0a3
[2]: https://github.com/alphagov/govuk_content_models/commit/6403139e1e0f627d0c55957d75e446ef3389976e
[3]: https://github.com/alphagov/govuk_content_models/commit/32b9cbcf3da0089a0edf0c247bf437ea1374744b