### PR TITLE
Bump to 28.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 28.7.0
+
+- Add `vehicle_recalls_and_faults_alert` artefact format
+
 ## 28.6.2
 
 - Relax constraint on govspeak dependency from `~> 3.1.0` to `~> 3.1`.

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "28.6.2"
+  VERSION = "28.7.0"
 end


### PR DESCRIPTION
Adds support for artefacts with a `kind` of `vehicle_recalls_and_faults_alert`, to be published from Specialist Publisher.