### PR TITLE
Make the scheduled publishing timestamp be London local time, not UTC

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -52,7 +52,7 @@ class Action
   def to_s
     if request_type == SCHEDULE_FOR_PUBLISHING
       string = "Scheduled for publishing"
-      string += " on #{request_details['scheduled_time'].strftime('%d/%m/%Y %H:%M %Z')}" if request_details['scheduled_time'].present?
+      string += " on #{request_details['scheduled_time'].to_datetime.in_time_zone('London').strftime('%d/%m/%Y %H:%M')}" if request_details['scheduled_time'].present?
       string
     else
       request_type.humanize.capitalize

--- a/test/models/action_test.rb
+++ b/test/models/action_test.rb
@@ -6,7 +6,7 @@ class ActionTest < ActiveSupport::TestCase
   end
 
   test "#to_s should contain the scheduled time when request type is SCHEDULE_FOR_PUBLISHING" do
-    assert_equal "Scheduled for publishing on 12/12/2014 00:00 UTC",
+    assert_equal "Scheduled for publishing on 12/12/2014 00:00",
       Action.new(:request_type => 'schedule_for_publishing',
                  :request_details => { 'scheduled_time' => Date.parse('12/12/2014').to_time.utc }).to_s
   end


### PR DESCRIPTION
- This is required by Publisher as publishing users were
  getting confused by things normally being in local time, and the
  History tab being in UTC, making them think that their document
  was going to be (or had been) published an hour too early.
- This is needed here because Publisher just calls
  `action.to_s`
  (https://github.com/alphagov/publisher/blob/master/app/views/shared/_edition_history.html.erb#L23),
  and `action` comes from here.
- The only test changed here is to remove the specifying of %Z
  (timezone abbreviation) as `strftime` no longer specifies it.

Pivotal: https://www.pivotaltracker.com/story/show/95556412.
Thanks to @bishboria for his help with this.

Screenshots of Publisher behaviour:

Before:

![screenshot 2015-06-09 11 03 19](https://cloud.githubusercontent.com/assets/355033/8055507/edfd3b56-0e97-11e5-9167-25babc27d87e.png)

After:

![screenshot 2015-06-09 10 49 48](https://cloud.githubusercontent.com/assets/355033/8055318/9bf2adb0-0e96-11e5-8f26-ba6a3d1d7db0.png)
