### PR TITLE
Add analytics profiles to transactions

### DIFF
--- a/app/models/transaction_edition.rb
+++ b/app/models/transaction_edition.rb
@@ -6,13 +6,16 @@ class TransactionEdition < Edition
   field :link, type: String
   field :more_information, type: String
   field :need_to_know, type: String
+  field :department_analytics_profile, type: String
   field :alternate_methods, type: String
 
   GOVSPEAK_FIELDS = [:introduction, :more_information, :alternate_methods, :need_to_know]
 
+  validates_format_of :department_analytics_profile, with: /UA-\d+-\d+/i, allow_blank: true
+
   @fields_to_clone = [:introduction, :will_continue_on, :link,
                       :more_information, :alternate_methods,
-                      :need_to_know]
+                      :need_to_know, :department_analytics_profile]
 
   def indexable_content
     "#{super} #{Govspeak::Document.new(introduction).to_text} #{Govspeak::Document.new(more_information).to_text}".strip

--- a/test/models/transaction_edition_test.rb
+++ b/test/models/transaction_edition_test.rb
@@ -6,6 +6,22 @@ class TransactionEditionTest < ActiveSupport::TestCase
     @artefact = FactoryGirl.create(:artefact)
   end
 
+  context 'Department analytics profiles' do
+    should "only allow valid Google Analytics profiles" do
+      transaction = FactoryGirl.create(:transaction_edition, panopticon_id: @artefact.id)
+
+      ['invalid', 'ua-12345', 'UA-1234A-1'].each do |id|
+        transaction.department_analytics_profile = id
+        refute transaction.valid?
+      end
+
+      ['ua-123456-1', 'UA-00-10'].each do |id|
+        transaction.department_analytics_profile = id
+        assert transaction.valid?
+      end
+    end
+  end
+
   context "indexable_content" do
     should "include the introduction without markup" do
       transaction = FactoryGirl.create(:transaction_edition, introduction: "## introduction", more_information: "", panopticon_id: @artefact.id)


### PR DESCRIPTION
Departments often want to track user journeys from transaction start pages through to their service. This will allow publishers to self serve.

* Validate Google Analytics profile matches UA-XXXXXX-X format (There are much older analytics profile IDs that begin with other characters)

https://trello.com/c/QyHwb1Zu/39-allow-editors-to-add-cross-domain-tracking-to-service-start-pages-medium

Background on GA profile IDs:
https://support.google.com/analytics/answer/1102152?hl=en