### PR TITLE
Remove deprecated fields

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -23,7 +23,6 @@ class Artefact
   # NOTE: these fields are deprecated, and soon to be replaced with a
   # tag-based implementation
   field "department",           type: String
-  field "business_proposition", type: Boolean, default: false
 
   field "name",                 type: String
   field "slug",                 type: String

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -38,7 +38,6 @@ class Artefact
   field "need_id",              type: String
 
   field "need_ids",             type: Array, default: []
-  field "fact_checkers",        type: String
   field "publication_id",       type: String
   field "description",          type: String
   field "state",                type: String,  default: "draft"

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -20,10 +20,6 @@ class Artefact
                   :keywords, :legacy_sources, :specialist_sectors, :organisations
   has_primary_tag_for :section
 
-  # NOTE: these fields are deprecated, and soon to be replaced with a
-  # tag-based implementation
-  field "department",           type: String
-
   field "name",                 type: String
   field "slug",                 type: String
   field "paths",                type: Array, default: []

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -17,7 +17,6 @@ class Edition
   field :publish_at,           type: DateTime
   field :overview,             type: String
   field :slug,                 type: String
-  field :department,           type: String
   field :rejected_count,       type: Integer,  default: 0
 
   field :browse_pages,         type: Array, default: []
@@ -195,7 +194,6 @@ class Edition
       :panopticon_id,
       :overview,
       :slug,
-      :department,
       :browse_pages,
       :primary_topic,
       :additional_topics
@@ -241,8 +239,7 @@ class Edition
     importing_user.create_edition(metadata.kind.to_sym,
       panopticon_id: metadata.id,
       slug: metadata.slug,
-      title: metadata.name,
-      department: metadata.department)
+      title: metadata.name)
   end
 
   def self.find_and_identify(slug, edition)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -10,7 +10,6 @@ class Edition
   field :panopticon_id,        type: String
   field :version_number,       type: Integer,  default: 1
   field :sibling_in_progress,  type: Integer,  default: nil
-  field :business_proposition, type: Boolean,  default: false
 
   field :title,                type: String
   field :in_beta,              type: Boolean,  default: false
@@ -243,8 +242,7 @@ class Edition
       panopticon_id: metadata.id,
       slug: metadata.slug,
       title: metadata.name,
-      department: metadata.department,
-      business_proposition: metadata.business_proposition)
+      department: metadata.department)
   end
 
   def self.find_and_identify(slug, edition)

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -204,7 +204,7 @@ module Workflow
     end
 
     def disallowable_change?
-      allowed_to_change = %w(slug publish_at department business_proposition)
+      allowed_to_change = %w(slug publish_at department)
       (changes.keys - allowed_to_change).present?
     end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -204,7 +204,7 @@ module Workflow
     end
 
     def disallowable_change?
-      allowed_to_change = %w(slug publish_at department)
+      allowed_to_change = %w(slug publish_at)
       (changes.keys - allowed_to_change).present?
     end
 end

--- a/test/models/artefact_action_test.rb
+++ b/test/models/artefact_action_test.rb
@@ -18,7 +18,6 @@ end
 class ArtefactActionTest < ActiveSupport::TestCase
 
   DEFAULTS = {
-    "business_proposition" => false,
     "active" => false,
     "tag_ids" => [],
     "tags" => [],

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -376,7 +376,6 @@ class ArtefactTest < ActiveSupport::TestCase
         name: "Foo bar",
         primary_section: "test-section",
         sections: ["test-section"],
-        department: "Test dept",
         owning_app: "publisher",
     )
 

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -16,7 +16,6 @@ class EditionTest < ActiveSupport::TestCase
         name: "Foo bar",
         # primary_section: "test-section",
         # sections: ["test-section"],
-        # department: "Test dept",
         owning_app: "publisher")
 
     AnswerEdition.create(state: "ready", slug: "childcare", panopticon_id: artefact.id,
@@ -153,10 +152,8 @@ class EditionTest < ActiveSupport::TestCase
                                   state: "published",
                                   panopticon_id: @artefact.id,
                                   version_number: 1,
-                                  department: "Test dept",
                                   overview: "I am a test overview")
     clone_edition = edition.build_clone
-    assert_equal "Test dept", clone_edition.department
     assert_equal "I am a test overview", clone_edition.overview
     assert_equal 2, clone_edition.version_number
   end
@@ -207,7 +204,6 @@ class EditionTest < ActiveSupport::TestCase
         state: "published",
         panopticon_id: @artefact.id,
         version_number: 1,
-        department: "Test dept",
         overview: "I am a test overview",
         video_url: "http://www.youtube.com/watch?v=dQw4w9WgXcQ"
     )
@@ -217,7 +213,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 2, new_edition.version_number
     assert_equal @artefact.id.to_s, new_edition.panopticon_id
     assert_equal "draft", new_edition.state
-    assert_equal "Test dept", new_edition.department
     assert_equal "I am a test overview", new_edition.overview
     assert_equal edition.whole_body, new_edition.whole_body
   end
@@ -228,7 +223,6 @@ class EditionTest < ActiveSupport::TestCase
       state: "published",
       panopticon_id: @artefact.id,
       version_number: 1,
-      department: "Test dept",
       licence_overview: "I am a test overview",
       licence_identifier: "Test identifier",
       licence_short_description: "I am a test short description",
@@ -241,7 +235,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 2, new_edition.version_number
     assert_equal @artefact.id.to_s, new_edition.panopticon_id
     assert_equal "draft", new_edition.state
-    assert_equal "Test dept", new_edition.department
     assert_equal "I am a test overview", new_edition.overview
     assert_equal edition.whole_body, new_edition.body
   end
@@ -252,7 +245,6 @@ class EditionTest < ActiveSupport::TestCase
         state: "published",
         panopticon_id: @artefact.id,
         version_number: 1,
-        department: "Test dept",
         overview: "I am a test overview"
     )
     new_edition = edition.build_clone AnswerEdition
@@ -261,7 +253,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 2, new_edition.version_number
     assert_equal @artefact.id.to_s, new_edition.panopticon_id
     assert_equal "draft", new_edition.state
-    assert_equal "Test dept", new_edition.department
     assert_equal "I am a test overview", new_edition.overview
     assert_equal edition.whole_body, new_edition.whole_body
   end
@@ -272,7 +263,6 @@ class EditionTest < ActiveSupport::TestCase
         state: "published",
         panopticon_id: @artefact.id,
         version_number: 1,
-        department: "Test dept",
         overview: "I am a test overview",
         more_information: "More information",
         alternate_methods: "Alternate methods"
@@ -283,7 +273,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 2, new_edition.version_number
     assert_equal @artefact.id.to_s, new_edition.panopticon_id
     assert_equal "draft", new_edition.state
-    assert_equal "Test dept", new_edition.department
     assert_equal "I am a test overview", new_edition.overview
     assert_equal edition.whole_body, new_edition.whole_body
   end
@@ -294,7 +283,6 @@ class EditionTest < ActiveSupport::TestCase
         state: "published",
         panopticon_id: @artefact.id,
         version_number: 1,
-        department: "Test dept",
         overview: "I am a test overview",
         body: "Test body"
     )
@@ -304,7 +292,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 2, new_edition.version_number
     assert_equal @artefact.id.to_s, new_edition.panopticon_id
     assert_equal "draft", new_edition.state
-    assert_equal "Test dept", new_edition.department
     assert_equal "I am a test overview", new_edition.overview
     assert_equal "Test body", new_edition.more_information
   end
@@ -315,7 +302,6 @@ class EditionTest < ActiveSupport::TestCase
       state: "published",
       panopticon_id: @artefact.id,
       version_number: 1,
-      department: "Test dept",
       overview: "I am a test overview",
       body: "Test body"
     )
@@ -325,7 +311,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 2, new_edition.version_number
     assert_equal @artefact.id.to_s, new_edition.panopticon_id
     assert_equal "draft", new_edition.state
-    assert_equal "Test dept", new_edition.department
     assert_equal "I am a test overview", new_edition.overview
     assert_equal "Test body", new_edition.body
   end
@@ -336,7 +321,6 @@ class EditionTest < ActiveSupport::TestCase
         state: "published",
         panopticon_id: @artefact.id,
         version_number: 1,
-        department: "Test dept",
         overview: "I am a test overview",
         video_url: "http://www.youtube.com/watch?v=dQw4w9WgXcQ"
     )
@@ -346,7 +330,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 2, new_edition.version_number
     assert_equal @artefact.id.to_s, new_edition.panopticon_id
     assert_equal "draft", new_edition.state
-    assert_equal "Test dept", new_edition.department
     assert_equal "I am a test overview", new_edition.overview
     assert_equal edition.whole_body, new_edition.more_information
   end
@@ -357,7 +340,6 @@ class EditionTest < ActiveSupport::TestCase
         state: "published",
         panopticon_id: @artefact.id,
         version_number: 1,
-        department: "Test dept",
         overview: "I am a test overview",
     )
     new_edition = edition.build_clone TransactionEdition
@@ -366,7 +348,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 2, new_edition.version_number
     assert_equal @artefact.id.to_s, new_edition.panopticon_id
     assert_equal "draft", new_edition.state
-    assert_equal "Test dept", new_edition.department
     assert_equal "I am a test overview", new_edition.overview
     assert_equal edition.whole_body, new_edition.more_information
   end
@@ -377,7 +358,6 @@ class EditionTest < ActiveSupport::TestCase
         state: "published",
         panopticon_id: @artefact.id,
         version_number: 1,
-        department: "Test dept",
         overview: "I am a test overview",
     )
     new_edition = edition.build_clone GuideEdition
@@ -386,7 +366,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 2, new_edition.version_number
     assert_equal @artefact.id.to_s, new_edition.panopticon_id
     assert_equal "draft", new_edition.state
-    assert_equal "Test dept", new_edition.department
     assert_equal "I am a test overview", new_edition.overview
   end
 
@@ -446,7 +425,6 @@ class EditionTest < ActiveSupport::TestCase
         slug: "foo-bar",
         kind: "answer",
         name: "Foo bar",
-        department: "Test dept",
         owning_app: "publisher",
     )
     artefact.save!
@@ -459,7 +437,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_kind_of AnswerEdition, publication
     assert_equal artefact.name, publication.title
     assert_equal artefact.id.to_s, publication.panopticon_id.to_s
-    assert_equal artefact.department, publication.department
   end
 
   test "should not change edition metadata if archived" do
@@ -470,7 +447,6 @@ class EditionTest < ActiveSupport::TestCase
         name: "Foo bar",
         primary_section: "test-section",
         sections: ["test-section"],
-        department: "Test dept",
         owning_app: "publisher",
     )
 
@@ -907,7 +883,6 @@ class EditionTest < ActiveSupport::TestCase
         name: "Foo bar",
         primary_section: "test-section",
         sections: ["test-section"],
-        department: "Test dept",
         owning_app: "publisher",
     )
 


### PR DESCRIPTION
These fields have become obsolete. Related PRs:
https://github.com/alphagov/govuk_content_api/pull/223
https://github.com/alphagov/publisher/pull/405
https://github.com/alphagov/panopticon/pull/268

Aside:
I started looking at removing the deprecated singular "need_id" field but decided to defer it to avoid making these PRs too large.