### PR TITLE
Only update editions when the artefact slug changes

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -284,9 +284,11 @@ class Artefact
   def update_editions
     case state
     when 'draft'
-      Edition.where(:state.nin => ["archived"],
-                    panopticon_id: self.id).each do |edition|
-        edition.update_slug_from_artefact(self)
+      if self.slug_changed?
+        Edition.where(:state.nin => ["archived"],
+                      panopticon_id: self.id).each do |edition|
+          edition.update_slug_from_artefact(self)
+        end
       end
     when 'archived'
       archive_editions

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -330,6 +330,19 @@ class ArtefactTest < ActiveSupport::TestCase
     assert_equal artefact.slug, edition.slug
   end
 
+  should "not touch the updated_at field on the editions when the artefact is saved but the slug hasn't changed" do
+    artefact = FactoryGirl.create(:draft_artefact)
+    edition = FactoryGirl.create(:answer_edition, panopticon_id: artefact.id)
+    old_updated_at = 2.days.ago.to_time
+    edition.set(:updated_at, old_updated_at)
+
+    artefact.language = "cy"
+    artefact.save!
+
+    edition.reload
+    assert_equal old_updated_at.utc.iso8601, edition.updated_at.utc.iso8601
+  end
+
   should "not update the edition's slug when a live artefact is saved" do
     artefact = FactoryGirl.create(:live_artefact, slug: "something-something-live")
     edition = FactoryGirl.create(:answer_edition, panopticon_id: artefact.id, slug: "something-else")


### PR DESCRIPTION
Before this change, any time an Artefact was updated in Panopticon, the edition
would have `save!` called on it, which would update the `updated_at` field on
all the non-archived editions. For example, this included hundreds of items
where the content was re-tagged to live in the new Topics.

This was a problem because the updated_at field is used to see what editions
have been worked on recently - it is really important in the content designers'
workflow.

Given that the intent was only to update the slug on the editions if it had
changed on the artefact then let's only call the method when the slug has
changed.

The alternative would be to update the slug on the editions without triggering
callbacks, but that seems potentially risky and expectation-subverting.