### PR TITLE
Keep Simple Smart Answer question answer slugs up to date

### DIFF
--- a/app/models/simple_smart_answer_edition/node/option.rb
+++ b/app/models/simple_smart_answer_edition/node/option.rb
@@ -17,13 +17,13 @@ class SimpleSmartAnswerEdition < Edition
       validates :label, :next_node, presence: true
       validates :slug, :format => {:with => /\A[a-z0-9-]+\z/}
 
-      before_validation :populate_slug_if_blank
+      before_validation :populate_slug
 
       private
 
-      def populate_slug_if_blank
-        if self.slug.blank? and self.label.present?
-          self.slug = ActiveSupport::Inflector.parameterize(self.label)
+      def populate_slug
+        if label.present? && !slug_changed?
+          self.slug = ActiveSupport::Inflector.parameterize(label)
         end
       end
     end

--- a/test/models/simple_smart_answer_option_test.rb
+++ b/test/models/simple_smart_answer_option_test.rb
@@ -66,6 +66,13 @@ class SimpleSmartAnswerOptionTest < ActiveSupport::TestCase
         assert_equal "yes", @option.slug
       end
 
+      should "keep the slug up to date if the label changes" do
+        @option = @node.options.create(@atts.merge(slug: "most-likely"))
+        @option.label = "Most of the times"
+        assert @option.valid?
+        assert_equal "most-of-the-times", @option.slug
+      end
+
       should "not overwrite a given slug" do
         @option = @node.options.build(@atts.merge(:slug => "fooey"))
 


### PR DESCRIPTION
This was reported as a very annoying bug by the content team.

```
Scenario:
  Given there is a simple smartanswer with one question that has two possible
  answers 'Red' and 'White' that lead to two outcomes 'outcome_1' and
  'outcome_2'
  Then the url slug leading to the 'outcome_1' is '/y/red/outcome_1'
  When I change the 'Red' answer to 'Purple'
  Then the url slug leading to the 'outcome_1' should be '/y/purple/outcome_1'
     not '/y/red/outcome_1'
```

Currently content designers have to delete the option and re-do the question from
scratch to get the correct URL slugs.

If/once this is merged, I'll need to bump the version of this gem and update the dependency on publisher. 