### PR TITLE
Allow detailed guide slugs to start with /guidance

### DIFF
--- a/app/validators/slug_validator.rb
+++ b/app/validators/slug_validator.rb
@@ -8,6 +8,7 @@ class SlugValidator < ActiveModel::EachValidator
       FinderEmailSignupValidator,
       GovernmentPageValidator,
       BrowsePageValidator,
+      DetailedGuideValidator,
       DefaultValidator
     ].map { |klass| klass.new(record, attribute, value) }
 
@@ -126,6 +127,16 @@ protected
       unless url_parts.all? { |url_part| valid_slug?(url_part) }
         record.errors[attribute] << "must be usable in a URL"
       end
+    end
+  end
+
+  class DetailedGuideValidator <InstanceValidator
+    def applicable?
+      of_kind?('detailed_guide')
+    end
+
+    def validate!
+      record.errors[attribute] << "must be a valid URL either at the root or under 'guidance/'" unless value.match(%r{^(guidance/)?[a-z0-9\-_]+$})
     end
   end
 

--- a/app/validators/slug_validator.rb
+++ b/app/validators/slug_validator.rb
@@ -130,7 +130,7 @@ protected
     end
   end
 
-  class DetailedGuideValidator <InstanceValidator
+  class DetailedGuideValidator < InstanceValidator
     def applicable?
       of_kind?('detailed_guide')
     end

--- a/test/validators/slug_validator_test.rb
+++ b/test/validators/slug_validator_test.rb
@@ -93,4 +93,19 @@ class SlugTest < ActiveSupport::TestCase
       refute document_with_slug("oil-and-gas/not.a.valid.slug", kind: "specialist_sector").valid?
     end
   end
+
+  context "Detailed guides slugs" do
+    should "allow a '/' in the slug" do
+      assert document_with_slug("guidance/british-forces-overseas-posting-cyprus", kind: "detailed_guide").valid?
+    end
+
+    should "allow only one '/' in the slug" do
+      refute document_with_slug("guidance/british-forces-overseas-posting-cyprus/more-information", kind: "detailed_guide").valid?
+    end
+
+    should "ensure it allows slugs that start at the root" do
+      assert document_with_slug("british-forces-overseas-posting-cyprus", kind: "detailed_guide").valid?
+    end
+    #TODO: disallow this once guidance migration has been complete
+  end
 end


### PR DESCRIPTION
This is part of the [RFC](https://gov-uk.atlassian.net/wiki/pages/viewpage.action?pageId=32604340) to move detailed guides paths from the root to guidance/.

cc @boffbowsh @jamiecobbett 