### PR TITLE
Bump to 29.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
+## 29.1.1
+
+- Bugfix: update question options slugs when their labels are updated
+
 ## 29.1.0
+
 - Allow detailed guide slugs to start with /guidance
 
 ## 29.0.1

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "29.1.0"
+  VERSION = "29.1.1"
 end


### PR DESCRIPTION
This release adds a bugfix to keep Simple Smart Answers' url slugs up to date with their label values.