### PR TITLE
Add utiac_decision to specialist-publisher list

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -85,6 +85,7 @@ class Artefact
                                   "manual",
                                   "medical_safety_alert",
                                   "raib_report",
+                                  "utiac_decision",
                                   "vehicle_recalls_and_faults_alert"],
     "finder-api"              => ["finder",
                                   "finder_email_signup"],


### PR DESCRIPTION
Add Upper Tribunal Immigration and Asylum Chamber decision to specialist-publisher list.