### PR TITLE
Add content ID to Artefacts

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -43,6 +43,12 @@ class Artefact
   field "public_timestamp",     type: DateTime
   field "redirect_url",         type: String
 
+  # content_id should be unique but we have existing artefacts without it.
+  # We should therefore enforce the uniqueness as soon as:
+  #  - every current artefact will have a content id assigned
+  #  - every future artefact will be created with a content id
+  field "content_id",           type: String
+
   index "slug", :unique => true
 
   # This index allows the `relatable_artefacts` method to use an index-covered


### PR DESCRIPTION
We want to use content IDs instead of slugs to represent items in curated
lists, so that things like slug changes don't break the linkage. In order to do
this, we need to ensure that all content in publisher has a content-id, and
these content-ids are published to the publishing API.

Tested locally with:
https://github.com/alphagov/publisher/compare/send-content-id-to-content-store

Part of:
https://trello.com/c/rmBoBPm9/290-ensure-that-all-content-in-publisher-has-a-content-id