### PR TITLE
Simplify changing Edition types

### DIFF
--- a/app/models/answer_edition.rb
+++ b/app/models/answer_edition.rb
@@ -5,8 +5,6 @@ class AnswerEdition < Edition
 
   GOVSPEAK_FIELDS = [:body]
 
-  @fields_to_clone = [:body]
-
   def whole_body
     self.body
   end

--- a/app/models/business_support_edition.rb
+++ b/app/models/business_support_edition.rb
@@ -42,8 +42,8 @@ class BusinessSupportEdition < Edition
   @fields_to_clone = [:body, :min_value, :max_value, :max_employees, :organiser,
       :eligibility, :evaluation, :additional_information, :continuation_link,
       :will_continue_on, :contact_details, :short_description, :priority, :areas,
-      :business_sizes, :locations, :purposes, :sectors, :stages, :support_types,
-      :start_date, :end_date]
+      :business_types, :business_sizes, :locations, :purposes, :sectors, :stages,
+      :support_types, :start_date, :end_date]
 
   scope :for_facets, lambda { |facets|
     where({ "$and" => facets_criteria(facets) }).order_by([:priority, :desc], [:title, :asc])

--- a/app/models/business_support_edition.rb
+++ b/app/models/business_support_edition.rb
@@ -39,12 +39,6 @@ class BusinessSupportEdition < Edition
   # https://github.com/mongoid/mongoid/issues/1735 Really Mongoid‽
   validates :min_value, :max_value, :max_employees, :numericality => {:allow_nil => true, :only_integer => true}
 
-  @fields_to_clone = [:body, :min_value, :max_value, :max_employees, :organiser,
-      :eligibility, :evaluation, :additional_information, :continuation_link,
-      :will_continue_on, :contact_details, :short_description, :priority, :areas,
-      :business_types, :business_sizes, :locations, :purposes, :sectors, :stages,
-      :support_types, :start_date, :end_date]
-
   scope :for_facets, lambda { |facets|
     where({ "$and" => facets_criteria(facets) }).order_by([:priority, :desc], [:title, :asc])
   }

--- a/app/models/campaign_edition.rb
+++ b/app/models/campaign_edition.rb
@@ -14,11 +14,6 @@ class CampaignEdition < Edition
 
   GOVSPEAK_FIELDS = [:body]
 
-  @fields_to_clone = [
-    :body, :large_image_id, :medium_image_id, :small_image_id,
-    :organisation_formatted_name, :organisation_url, :organisation_brand_colour, :organisation_crest
-  ]
-
   BRAND_COLOURS = [
     "attorney-generals-office",
     "cabinet-office",

--- a/app/models/completed_transaction_edition.rb
+++ b/app/models/completed_transaction_edition.rb
@@ -7,8 +7,6 @@ class CompletedTransactionEdition < Edition
 
   GOVSPEAK_FIELDS = [:body]
 
-  @fields_to_clone = [:body, :presentation_toggles]
-
   def whole_body
     self.body
   end

--- a/app/models/completed_transaction_edition.rb
+++ b/app/models/completed_transaction_edition.rb
@@ -7,10 +7,9 @@ class CompletedTransactionEdition < Edition
 
   GOVSPEAK_FIELDS = [:body]
 
-  @fields_to_clone = [:body]
+  @fields_to_clone = [:body, :presentation_toggles]
 
   def whole_body
     self.body
   end
-
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -174,7 +174,19 @@ class Edition
   # we are changing the type of the edition, any fields other than the base
   # fields will likely be meaningless.
   def fields_to_copy(target_class)
-    target_class == self.class ? self.class.fields_to_clone : []
+    return_value = [
+      :title,
+      :panopticon_id,
+      :overview,
+      :slug,
+      :browse_pages,
+      :primary_topic,
+      :additional_topics
+    ]
+    if target_class == self.class
+      return_value += self.class.fields_to_clone
+    end
+    return_value
   end
 
   def build_clone(target_class=nil)
@@ -187,19 +199,9 @@ class Edition
     end
 
     target_class = self.class unless target_class
-    new_edition = target_class.new(title: self.title,
-                                    version_number: get_next_version_number)
+    new_edition = target_class.new(version_number: get_next_version_number)
 
-    real_fields_to_merge = fields_to_copy(target_class) + [
-      :panopticon_id,
-      :overview,
-      :slug,
-      :browse_pages,
-      :primary_topic,
-      :additional_topics
-    ]
-
-    real_fields_to_merge.each do |attr|
+    fields_to_copy(target_class).each do |attr|
       new_edition[attr] = read_attribute(attr)
     end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -203,10 +203,6 @@ class Edition
       new_edition[attr] = read_attribute(attr)
     end
 
-    if target_class == AnswerEdition and self.is_a?(LicenceEdition)
-      new_edition.overview = licence_overview
-    end
-
     # If the type is changing, then take the combined body (whole_body) from
     # the old and decide where to put it in the new.
     #

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -66,9 +66,6 @@ class Edition
   index "created_at"
   index "updated_at"
 
-  class << self; attr_accessor :fields_to_clone end
-  @fields_to_clone = []
-
   alias_method :admin_list_title, :title
 
   def series
@@ -184,7 +181,8 @@ class Edition
       :additional_topics
     ]
     if target_class == self.class
-      return_value += self.class.fields_to_clone
+      type_specific_keys = self.fields.keys - Edition.fields.keys
+      return_value += type_specific_keys
     end
     return_value
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -203,26 +203,26 @@ class Edition
       new_edition[attr] = read_attribute(attr)
     end
 
-    if target_class == AnswerEdition and %w(GuideEdition ProgrammeEdition TransactionEdition).include?(self.class.name)
-      new_edition.body = whole_body
-    end
-
     if target_class == AnswerEdition and self.is_a?(LicenceEdition)
-      new_edition.body = whole_body
       new_edition.overview = licence_overview
     end
 
-    if target_class == SimpleSmartAnswerEdition && %w(AnswerEdition GuideEdition ProgrammeEdition TransactionEdition).include?(self.class.name)
-      new_edition.body = whole_body
-    end
-
-    if target_class == TransactionEdition and %w(AnswerEdition GuideEdition ProgrammeEdition).include?(self.class.name)
-      new_edition.more_information = whole_body
-    end
-
-    if target_class == GuideEdition and self.is_a?(AnswerEdition)
-      new_edition.parts.build(title: "Part One", body: whole_body,
-                              slug: "part-one")
+    # If the type is changing, then take the combined body (whole_body) from
+    # the old and decide where to put it in the new.
+    #
+    # Where the type is not changing, the body will already have been copied
+    # above.
+    #
+    # We don't need to copy parts between Parted types here, because the Parted
+    # module does that.
+    if target_class != self.class
+      if new_edition.respond_to?(:parts) and !self.respond_to?(:parts)
+        new_edition.parts.build(title: "Part One", body: whole_body, slug: "part-one")
+      elsif new_edition.respond_to?(:more_information=)
+        new_edition.more_information = whole_body
+      elsif new_edition.respond_to?(:body=)
+        new_edition.body = whole_body
+      end
     end
 
     new_edition

--- a/app/models/guide_edition.rb
+++ b/app/models/guide_edition.rb
@@ -8,7 +8,6 @@ class GuideEdition < Edition
   field :video_summary, type: String
 
   GOVSPEAK_FIELDS = []
-  @fields_to_clone = [:video_url, :video_summary]
 
   def has_video?
     video_url.present?

--- a/app/models/help_page_edition.rb
+++ b/app/models/help_page_edition.rb
@@ -5,8 +5,6 @@ class HelpPageEdition < Edition
 
   GOVSPEAK_FIELDS = [:body]
 
-  @fields_to_clone = [:body]
-
   def whole_body
     self.body
   end

--- a/app/models/licence_edition.rb
+++ b/app/models/licence_edition.rb
@@ -14,9 +14,6 @@ class LicenceEdition < Edition
   validate :licence_identifier_unique
   validates_format_of :continuation_link, :with => URI::regexp(%w(http https)), :allow_blank => true
 
-  @fields_to_clone = [:licence_identifier, :licence_short_description,
-                      :licence_overview, :will_continue_on, :continuation_link]
-
   def whole_body
     [licence_short_description, licence_overview].join("\n\n")
   end

--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -11,7 +11,7 @@ class LocalTransactionEdition < Edition
   GOVSPEAK_FIELDS = [:introduction, :more_information, :need_to_know]
 
   @fields_to_clone = [
-    :lgsl_code, :introduction, :more_information, :need_to_know
+    :lgsl_code, :lgil_override, :introduction, :more_information, :need_to_know
   ]
 
   validate :valid_lgsl_code

--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -10,10 +10,6 @@ class LocalTransactionEdition < Edition
 
   GOVSPEAK_FIELDS = [:introduction, :more_information, :need_to_know]
 
-  @fields_to_clone = [
-    :lgsl_code, :lgil_override, :introduction, :more_information, :need_to_know
-  ]
-
   validate :valid_lgsl_code
 
   def valid_lgsl_code

--- a/app/models/place_edition.rb
+++ b/app/models/place_edition.rb
@@ -8,8 +8,6 @@ class PlaceEdition < Edition
 
   GOVSPEAK_FIELDS = [:introduction, :more_information, :need_to_know]
 
-  @fields_to_clone = [:introduction, :more_information, :place_type, :need_to_know]
-
   def whole_body
     self.introduction
   end

--- a/app/models/programme_edition.rb
+++ b/app/models/programme_edition.rb
@@ -7,7 +7,6 @@ class ProgrammeEdition < Edition
   before_save :setup_default_parts, on: :create
 
   GOVSPEAK_FIELDS = []
-  @fields_to_clone = []
 
   DEFAULT_PARTS = [
     {title: "Overview", slug: "overview"},

--- a/app/models/simple_smart_answer_edition.rb
+++ b/app/models/simple_smart_answer_edition.rb
@@ -16,12 +16,15 @@ class SimpleSmartAnswerEdition < Edition
   @fields_to_clone = [:body]
 
   def whole_body
-    body
+    parts = [body]
+    unless nodes.nil?
+      parts += nodes.map { |node| "#{node.kind}: #{node.title} \n\n #{node.body}" }
+    end
+    parts.join("\n\n\n")
   end
 
   def build_clone(target_class=nil)
     new_edition = super(target_class)
-    new_edition.body = self.body
 
     if new_edition.is_a?(SimpleSmartAnswerEdition)
       self.nodes.each {|n| new_edition.nodes << n.clone }

--- a/app/models/simple_smart_answer_edition.rb
+++ b/app/models/simple_smart_answer_edition.rb
@@ -13,8 +13,6 @@ class SimpleSmartAnswerEdition < Edition
 
   GOVSPEAK_FIELDS = [:body]
 
-  @fields_to_clone = [:body]
-
   def whole_body
     parts = [body]
     unless nodes.nil?

--- a/app/models/transaction_edition.rb
+++ b/app/models/transaction_edition.rb
@@ -13,10 +13,6 @@ class TransactionEdition < Edition
 
   validates_format_of :department_analytics_profile, with: /UA-\d+-\d+/i, allow_blank: true
 
-  @fields_to_clone = [:introduction, :will_continue_on, :link,
-                      :more_information, :alternate_methods,
-                      :need_to_know, :department_analytics_profile]
-
   def indexable_content
     "#{super} #{Govspeak::Document.new(introduction).to_text} #{Govspeak::Document.new(more_information).to_text}".strip
   end

--- a/app/models/video_edition.rb
+++ b/app/models/video_edition.rb
@@ -10,8 +10,6 @@ class VideoEdition < Edition
 
   GOVSPEAK_FIELDS = [:body]
 
-  @fields_to_clone = [:video_url, :video_summary, :body]
-
   attaches :caption_file
 
   def has_video?

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -235,7 +235,8 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 2, new_edition.version_number
     assert_equal @artefact.id.to_s, new_edition.panopticon_id
     assert_equal "draft", new_edition.state
-    assert_equal "I am a test overview", new_edition.overview
+    assert_match /#{edition.licence_overview}/, new_edition.body
+    assert_match /#{edition.licence_short_description}/, new_edition.body
     assert_equal edition.whole_body, new_edition.body
   end
 

--- a/test/models/simple_smart_answer_edition_test.rb
+++ b/test/models/simple_smart_answer_edition_test.rb
@@ -56,7 +56,7 @@ class SimpleSmartAnswerEditionTest < ActiveSupport::TestCase
 
     new_edition = edition.build_clone(AnswerEdition)
 
-    assert_equal edition.body, new_edition.body
+    assert_equal "This smart answer is somewhat unique and calls for a different kind of introduction\n\n\nquestion: You approach two open doors. Which do you choose? \n\n ", new_edition.body
 
     assert new_edition.is_a?(AnswerEdition)
     assert ! new_edition.respond_to?(:nodes)


### PR DESCRIPTION
The old code had lots of hard-coded bespoke conditions that examined the types
of the objects to decide what to copy. This changes it to use duck typing to
figure out what data can be copied between types.

This approach is shorter, simpler and handles more conversions and will handle
new types without them having to be explicitly added. I think it also reveals the
intent better.

The only downside I could think of is if there are fields which are in common between two formats would be duplicated in the fields _and_ the new body, but that seems better than losing them because they haven't been explicitly handled one-by-one.