### PR TITLE
Remove redundant parameter in find_or_create_from_panopticon_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 31.0.0 (Unreleased)
+
+- `Edition.find_or_create_from_panopticon_data` no longer takes a third
+   parameter.
+
 ## 30.0.0
 
 - Add:

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -224,8 +224,7 @@ class Edition
     new_edition
   end
 
-  def self.find_or_create_from_panopticon_data(panopticon_id,
-                                               importing_user, api_credentials)
+  def self.find_or_create_from_panopticon_data(panopticon_id, importing_user)
     existing_publication = Edition.where(panopticon_id: panopticon_id)
                                   .order_by([:version_number, :desc]).first
     return existing_publication if existing_publication

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -393,7 +393,7 @@ class ArtefactTest < ActiveSupport::TestCase
     )
 
     user1 = FactoryGirl.create(:user)
-    edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user1, {})
+    edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user1)
     edition.state = "published"
     edition.save!
 
@@ -414,7 +414,7 @@ class ArtefactTest < ActiveSupport::TestCase
         owning_app: "publisher",
     )
     user1 = FactoryGirl.create(:user)
-    edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user1, {})
+    edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user1)
 
     refute artefact.any_editions_published?
 

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -451,7 +451,7 @@ class EditionTest < ActiveSupport::TestCase
     a = Artefact.find(artefact.id)
     user = User.create
 
-    publication = Edition.find_or_create_from_panopticon_data(artefact.id, user, {})
+    publication = Edition.find_or_create_from_panopticon_data(artefact.id, user)
 
     assert_kind_of AnswerEdition, publication
     assert_equal artefact.name, publication.title
@@ -530,7 +530,7 @@ class EditionTest < ActiveSupport::TestCase
 
   test "deleting a newer draft of a published edition removes sibling information" do
     user1 = FactoryGirl.create(:user)
-    edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1, {})
+    edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1)
     edition.update_attribute(:state, "published")
     second_edition = edition.build_clone
     second_edition.save!
@@ -546,7 +546,7 @@ class EditionTest < ActiveSupport::TestCase
 
   test "the latest edition should remove sibling_in_progress details if it is present" do
     user1 = FactoryGirl.create(:user)
-    edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1, {})
+    edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1)
     edition.update_attribute(:state, "published")
 
     # simulate a document having a newer edition destroyed (previous behaviour).
@@ -561,7 +561,7 @@ class EditionTest < ActiveSupport::TestCase
     FactoryGirl.create(:live_tag, tag_id: "test-section", title: "Test section", tag_type: "section")
 
     user1 = FactoryGirl.create(:user)
-    edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1, {})
+    edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1)
 
     assert_difference "Artefact.count", -1 do
       edition.destroy
@@ -572,7 +572,7 @@ class EditionTest < ActiveSupport::TestCase
 
     FactoryGirl.create(:live_tag, tag_id: "test-section", title: "Test section", tag_type: "section")
     user1 = FactoryGirl.create(:user)
-    edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1, {})
+    edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1)
     edition.update_attribute(:state, "published")
 
     edition.reload
@@ -905,7 +905,7 @@ class EditionTest < ActiveSupport::TestCase
         owning_app: "publisher",
     )
 
-    edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user, {})
+    edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user)
 
     assert_equal user.name, edition.creator
   end


### PR DESCRIPTION
This stopped being used for anything in 2012:
62a3e7cf46c4f2b707e5f922f2a90b741bcb661a (hi @mnowster).

The argument is [still passed by Publisher](https://github.com/search?q=user%3Aalphagov+find_or_create_from_panopticon_data&type=Code&utf8=%E2%9C%93), but that can be easily changed
when Publisher is upgraded to this version of the code.