### PR TITLE
Gss area codes for business support editions

### DIFF
--- a/app/models/business_support_edition.rb
+++ b/app/models/business_support_edition.rb
@@ -29,6 +29,7 @@ class BusinessSupportEdition < Edition
   field :start_date,      type: Date
   field :end_date,        type: Date
   field :areas,           type: Array, default: []
+  field :area_gss_codes,  type: Array, default: []
 
   GOVSPEAK_FIELDS = [:body, :eligibility, :evaluation, :additional_information]
 

--- a/test/models/business_support_edition_test.rb
+++ b/test/models/business_support_edition_test.rb
@@ -7,7 +7,10 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
   end
 
   should "have custom fields" do
-    support = FactoryGirl.create(:business_support_edition, panopticon_id: @artefact.id)
+    support = FactoryGirl.create(
+      :business_support_edition,
+      panopticon_id: @artefact.id,
+    )
     support.short_description = "The short description"
     support.body = "The body"
     support.eligibility = "The eligibility"
@@ -64,7 +67,10 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
   end
 
   should "not allow max_value to be less than min_value" do
-    support = FactoryGirl.create(:business_support_edition, panopticon_id: @artefact.id)
+    support = FactoryGirl.create(
+      :business_support_edition,
+      panopticon_id: @artefact.id,
+    )
     support.min_value = 100
     support.max_value = 50
 
@@ -106,7 +112,10 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
   context "continuation_link validation" do
 
     setup do
-      @bs = FactoryGirl.create(:business_support_edition, panopticon_id: @artefact.id)
+      @bs = FactoryGirl.create(
+        :business_support_edition,
+        panopticon_id: @artefact.id,
+      )
     end
 
     should "not validate the continuation link when blank" do
@@ -125,31 +134,33 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
   end
 
   should "clone extra fields when cloning edition" do
-    support = FactoryGirl.create(:business_support_edition,
-                                 :panopticon_id => @artefact.id,
-                                 :state => "published",
-                                 :short_description => "Short description of support format",
-                                 :body => "Body to be cloned",
-                                 :min_value => 1,
-                                 :max_value => 2,
-                                 :max_employees => 3,
-                                 :organiser => "Organiser to be cloned",
-                                 :eligibility => "Eligibility to be cloned",
-                                 :evaluation => "Evaluation to be cloned",
-                                 :additional_information => "Additional info to be cloned",
-                                 :will_continue_on => "Continuation text to be cloned",
-                                 :continuation_link => "http://www.gov.uk",
-                                 :contact_details => "Contact details to be cloned",
-                                 :priority => 2,
-                                 :areas => ['123','9999'],
-                                 :business_sizes => ['up-to-249'],
-                                 :locations => ['london'],
-                                 :purposes => ['start-up'],
-                                 :sectors => ['agriculture','manufacturing'],
-                                 :stages => ['grow-and-sustain'],
-                                 :support_types => ['grant','loan'],
-                                 :start_date => 1.year.ago(Date.today),
-                                 :end_date => 1.year.since(Date.today))
+    support = FactoryGirl.create(
+      :business_support_edition,
+      :panopticon_id => @artefact.id,
+      :state => "published",
+      :short_description => "Short description of support format",
+      :body => "Body to be cloned",
+      :min_value => 1,
+      :max_value => 2,
+      :max_employees => 3,
+      :organiser => "Organiser to be cloned",
+      :eligibility => "Eligibility to be cloned",
+      :evaluation => "Evaluation to be cloned",
+      :additional_information => "Additional info to be cloned",
+      :will_continue_on => "Continuation text to be cloned",
+      :continuation_link => "http://www.gov.uk",
+      :contact_details => "Contact details to be cloned",
+      :priority => 2,
+      :areas => ['123','9999'],
+      :business_sizes => ['up-to-249'],
+      :locations => ['london'],
+      :purposes => ['start-up'],
+      :sectors => ['agriculture','manufacturing'],
+      :stages => ['grow-and-sustain'],
+      :support_types => ['grant','loan'],
+      :start_date => 1.year.ago(Date.today),
+      :end_date => 1.year.since(Date.today),
+    )
 
     new_support = support.build_clone
 
@@ -180,47 +191,78 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
 
   context "for facets" do
     setup do
-      @e1 = FactoryGirl.create(:business_support_edition,
-                              :areas => ['2345', '1234'],
-                              :business_sizes => ['1', 'up-to-1000000'],
-                              :locations => ['narnia'], :purposes => ['world-domination'],
-                              :sectors => ['agriculture', 'healthcare'],
-                              :stages => ['pivoting'], :support_types => ['award', 'grant', 'loan'])
-      @e2 = FactoryGirl.create(:business_support_edition,
-                              :areas => ['1212', '1234', '999'],
-                              :business_sizes => ['1', 'up-to-1000000'],
-                              :locations => ['hades', 'narnia'], :purposes => ['business-growth-and-expansion'],
-                              :sectors => ['education', 'healthcare'],
-                              :stages => ['start-up', 'pivoting'], :support_types => ['grant', 'loan', 'equity'])
-      @e3 = FactoryGirl.create(:business_support_edition,
-                              :areas => ['1234'],
-                              :business_sizes => ['up-to-249', 'up-to-1000000'],
-                              :locations => ['hades', 'chicken-town'], :purposes => ['making-the-most-of-the-internet'],
-                              :sectors => ['utilities'], :stages => ['start-up'], :support_types => ['grant'])
+      @e1 = FactoryGirl.create(
+        :business_support_edition,
+        :areas => ['2345', '1234'],
+        :business_sizes => ['1', 'up-to-1000000'],
+        :locations => ['narnia'],
+        :purposes => ['world-domination'],
+        :sectors => ['agriculture', 'healthcare'],
+        :stages => ['pivoting'],
+        :support_types => ['award', 'grant', 'loan'],
+      )
+      @e2 = FactoryGirl.create(
+        :business_support_edition,
+        :areas => ['1212', '1234', '999'],
+        :business_sizes => ['1', 'up-to-1000000'],
+        :locations => ['hades', 'narnia'],
+        :purposes => ['business-growth-and-expansion'],
+        :sectors => ['education', 'healthcare'],
+        :stages => ['start-up', 'pivoting'],
+        :support_types => ['grant', 'loan', 'equity'],
+      )
+      @e3 = FactoryGirl.create(
+        :business_support_edition,
+        :areas => ['1234'],
+        :business_sizes => ['up-to-249', 'up-to-1000000'],
+        :locations => ['hades', 'chicken-town'],
+        :purposes => ['making-the-most-of-the-internet'],
+        :sectors => ['utilities'],
+        :stages => ['start-up'],
+        :support_types => ['grant'],
+      )
     end
 
     should "only return editions matching the facet values provided" do
-      editions = BusinessSupportEdition.for_facets({:purposes => 'business-growth-and-expansion', :support_types => 'equity'})
+      editions = BusinessSupportEdition.for_facets({
+        :purposes => 'business-growth-and-expansion',
+        :support_types => 'equity',
+      })
       assert_equal [@e2], editions
-      editions = BusinessSupportEdition.for_facets({:business_sizes => '1,up-to-1000000', :locations => 'narnia'})
+      editions = BusinessSupportEdition.for_facets({
+        :business_sizes => '1,up-to-1000000',
+        :locations => 'narnia',
+      })
       assert_equal [@e1, @e2], editions
     end
     should "support searching with all the facet values" do
-      editions = BusinessSupportEdition.for_facets({:areas => '1234', :business_sizes => 'up-to-1000000', :locations => 'narnia,hades,chicken-town',
-                                                    :purposes => 'business-growth-and-expansion,making-the-most-of-the-internet,world-domination',
-                                                    :sectors => 'agriculture,healthcare,utilities', :stages => 'pivoting,start-up',
-                                                    :support_types => 'award,grant,loan'})
+      editions = BusinessSupportEdition.for_facets({
+        :areas => '1234',
+        :business_sizes => 'up-to-1000000',
+        :locations => 'narnia,hades,chicken-town',
+        :purposes => 'business-growth-and-expansion,making-the-most-of-the-internet,world-domination',
+        :sectors => 'agriculture,healthcare,utilities',
+        :stages => 'pivoting,start-up',
+        :support_types => 'award,grant,loan',
+      })
       assert_equal [@e1, @e2, @e3], editions
     end
     should "return nothing where no facet values match" do
-      editions = BusinessSupportEdition.for_facets({:business_sizes => 'up-to-a-bizillion', :locations => 'ecclefechan'})
+      editions = BusinessSupportEdition.for_facets({
+        :business_sizes => 'up-to-a-bizillion',
+        :locations => 'ecclefechan',
+      })
       assert_empty editions
     end
   end
 
   context "scheme dates" do
     should "should have year with 4 digits length" do
-      invalid_edition = FactoryGirl.build(:business_support_edition, start_date: Date.new(99, 12, 31), end_date: Date.new(99, 12, 31))
+      invalid_edition = FactoryGirl.build(
+        :business_support_edition,
+        start_date: Date.new(99, 12, 31),
+        end_date: Date.new(99, 12, 31),
+      )
 
       refute invalid_edition.valid?
 
@@ -230,7 +272,11 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
     end
 
     should "have start date earlier than end date" do
-      invalid_edition = FactoryGirl.build(:business_support_edition, start_date: 1.week.ago, end_date: 2.weeks.ago)
+      invalid_edition = FactoryGirl.build(
+        :business_support_edition,
+        start_date: 1.week.ago,
+        end_date: 2.weeks.ago,
+      )
 
       refute invalid_edition.valid?
       assert_includes invalid_edition.errors.full_messages, "Start date can't be later than end date"

--- a/test/models/business_support_edition_test.rb
+++ b/test/models/business_support_edition_test.rb
@@ -26,6 +26,7 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
 
     support.priority = 2
     support.areas = ["123","345","45","9"]
+    support.area_gss_codes = ["G123","G345","G45","G9"]
     support.business_sizes << "up-to-249"
     support.business_types << "charity"
     support.locations = ["scotland", "england"]
@@ -55,6 +56,7 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
     assert_equal 2, support.priority
 
     assert_equal ["123","345","45","9"], support.areas
+    assert_equal ["G123","G345","G45","G9"], support.area_gss_codes
     assert_equal ["up-to-249"], support.business_sizes
     assert_equal ["charity"], support.business_types
     assert_equal ["scotland", "england"], support.locations
@@ -152,6 +154,7 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
       :contact_details => "Contact details to be cloned",
       :priority => 2,
       :areas => ['123','9999'],
+      :area_gss_codes => ['G123','G9999'],
       :business_sizes => ['up-to-249'],
       :locations => ['london'],
       :purposes => ['start-up'],
@@ -179,6 +182,7 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
 
     assert_equal support.priority, new_support.priority
     assert_equal support.areas, new_support.areas
+    assert_equal support.area_gss_codes, new_support.area_gss_codes
     assert_equal support.business_sizes, new_support.business_sizes
     assert_equal support.locations, new_support.locations
     assert_equal support.purposes, new_support.purposes
@@ -194,6 +198,7 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
       @e1 = FactoryGirl.create(
         :business_support_edition,
         :areas => ['2345', '1234'],
+        :area_gss_codes => ['G2345', 'G1234'],
         :business_sizes => ['1', 'up-to-1000000'],
         :locations => ['narnia'],
         :purposes => ['world-domination'],
@@ -204,6 +209,7 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
       @e2 = FactoryGirl.create(
         :business_support_edition,
         :areas => ['1212', '1234', '999'],
+        :area_gss_codes => ['G1212', 'G1234', 'G999'],
         :business_sizes => ['1', 'up-to-1000000'],
         :locations => ['hades', 'narnia'],
         :purposes => ['business-growth-and-expansion'],
@@ -214,6 +220,7 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
       @e3 = FactoryGirl.create(
         :business_support_edition,
         :areas => ['1234'],
+        :area_gss_codes => ['G1234'],
         :business_sizes => ['up-to-249', 'up-to-1000000'],
         :locations => ['hades', 'chicken-town'],
         :purposes => ['making-the-most-of-the-internet'],
@@ -238,6 +245,7 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
     should "support searching with all the facet values" do
       editions = BusinessSupportEdition.for_facets({
         :areas => '1234',
+        :area_gss_codes => 'G1234',
         :business_sizes => 'up-to-1000000',
         :locations => 'narnia,hades,chicken-town',
         :purposes => 'business-growth-and-expansion,making-the-most-of-the-internet,world-domination',


### PR DESCRIPTION
Publisher and Business Support API are currently referring to a Business
Support Scheme's areas by their slugs.

This is apparently unstable, so we're moving towards using the areas' GSS Codes
(http://www.ons.gov.uk/ons/guide-method/geography/products/names--codes-and-look-ups/standard-names-and-codes/index.html)

Since the migration involves multiple applications and gems, we've decided to
first add the GSS Codes to the BusinessSupportEditions, then think about
removing the current area slugs after.