### PR TITLE
Add content_id to Tag model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 31.2.0
+
+- Add `content_id` to `Tag` model
+
 ## 31.1.0
 
 - `area_gss_codes` field for BusinessSupportEdition

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -12,6 +12,7 @@ class Tag
   field :short_description, type: String
   field :parent_id,         type: String
   field :state,             type: String, default: 'draft'
+  field :content_id,        type: String
 
   STATES = ['draft', 'live']
 


### PR DESCRIPTION
`collections-publisher` will start sending content_ids to panopticon soon. We need to explicitly support that.

https://trello.com/c/IgYwT6yM
https://github.com/alphagov/collections-publisher/pull/143