### PR TITLE
When archiving an artefact, allow invalid editions to be archived

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -294,7 +294,7 @@ class Artefact
     if state == 'archived'
       Edition.where(panopticon_id: self.id, :state.nin => ["archived"]).each do |edition|
         edition.new_action(self, "note", comment: "Artefact has been archived. Archiving this edition.")
-        edition.archive!
+        edition.perform_event_without_validations(:archive!)
       end
     end
   end
@@ -313,7 +313,7 @@ class Artefact
   def save_as(user, options={})
     default_action = new_record? ? "create" : "update"
     action_type = options.delete(:action_type) || default_action
-    record_action action_type, user: user
+    record_action(action_type, user: user)
     save(options)
   end
 

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -460,6 +460,21 @@ class ArtefactTest < ActiveSupport::TestCase
     end
   end
 
+  test "should not run validations on editions when archiving" do
+    artefact = FactoryGirl.create(:artefact, state: "live")
+    edition = FactoryGirl.create(:help_page_edition, panopticon_id: artefact.id, state: 'published')
+    user1 = FactoryGirl.create(:user)
+
+    # Make the edition invalid, check that it persisted the invalid state
+    edition.update_attribute(:title, nil)
+    assert_equal(nil, edition.reload.title)
+
+    artefact.update_attributes_as(user1, state: "archived")
+    artefact.save!
+
+    assert_equal("archived", edition.reload.state)
+  end
+
   test "should restrict what attributes can be updated on an edition that has an archived artefact" do
     artefact = FactoryGirl.create(:artefact, state: "live")
     edition = FactoryGirl.create(:programme_edition, panopticon_id: artefact.id, state: "published")


### PR DESCRIPTION
Before this change, attempting to archive an artefact with invalid editions
would successfully mark the artefact as archived, but the editions would be
left in their state.

We have published editions which are invalid because validation rules have been
introduced since they were last worked on/saved.

Ideally, the state machine transition for archiving would skip validations, but
state_machine doesn't seem to support this.

Successfully tested with known-problem examples in Panopticon in development.