### PR TITLE
Bugfix: Add "official_statistics" format as owned by Whitehall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Add "official_statistics" artefact format
+
 ## 31.2.1
 
 - Bugfix: don't run validations on editions when archiving an artefact

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -106,6 +106,7 @@ class Artefact
                                   "national_statistics",
                                   "news_story",
                                   "notice",
+                                  "official_statistics",
                                   "oral_statement",
                                   "policy",
                                   "policy_paper",


### PR DESCRIPTION
Recently Statistics were relabelled in Whitehall as Official
Statistics, including the parameterised document format name sent to
Panopticon. As Panopticon didn’t know about the format, the validations
were failing when Whitehall attempted to send the artefacts, causing
errors for Whitehall sidekiq jobs.

This PR adds the `official_statistics` format to `Artefact` for
Panopticon to pick up. Further investigation is required to determine
whether the old `statistics` format should be removed yet, or if a data
migration should be performed in Panopticon first to change the format
of the artefacts.