### PR TITLE
Copy matching type-specific fields

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -174,7 +174,7 @@ class Edition
     if target_class == self.class
       base_field_keys + type_specific_field_keys
     else
-      base_field_keys
+      base_field_keys + common_type_specific_field_keys(target_class)
     end
   end
 
@@ -340,5 +340,9 @@ private
 
   def type_specific_field_keys
     (self.fields.keys - Edition.fields.keys).map(&:to_sym)
+  end
+
+  def common_type_specific_field_keys(target_class)
+    ((self.fields.keys & target_class.fields.keys) - Edition.fields.keys).map(&:to_sym)
   end
 end

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -217,7 +217,7 @@ FactoryGirl.define do
     lgil_code 0
   end
 
-  factory :place_edition do
+  factory :place_edition, parent: :edition, class: 'PlaceEdition'  do
     title "Far far away"
     introduction "Test introduction"
     more_information "More information"

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -417,6 +417,12 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 7, new_edition.parts.size #there are 5 'default' parts plus an additional two created by the factory
   end
 
+  test "knows the common fields of two edition subclasses" do
+    to_copy = Set.new([:introduction, :need_to_know, :more_information])
+    result = Set.new(TransactionEdition.new.fields_to_copy(PlaceEdition))
+    assert to_copy.proper_subset?(result)
+  end
+
   # Mongoid 2.x marks array fields as dirty whenever they are accessed.
   # See https://github.com/mongoid/mongoid/issues/2311
   # This behaviour has been patched in lib/mongoid/monkey_patches.rb


### PR DESCRIPTION
This is part of work to convert any format to any format in publisher.
Until now, type-specific fields were copied into the whole_body. Now,
if the target class has the same type-specific field, it will be
copied over.

[Trello](https://trello.com/c/p7wzEHo0/79-self-serve-changing-a-format-to-any-format-in-mainstream-publisher-medium)