### PR TITLE
Allow redirects to external URLs & fragments

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -401,8 +401,15 @@ class Artefact
 
   def validate_redirect_url
     return unless self.redirect_url.present?
-    unless valid_url_path?(self.redirect_url)
+    unless valid_redirect_url_path?(self.redirect_url)
       errors[:redirect_url] << "is not a valid redirect target"
     end
+  end
+
+  def valid_redirect_url_path?(target)
+    URI.parse(target)
+    target.starts_with?("/") && target !~ %r{//} && target !~ %r{./\z}
+  rescue URI::InvalidURIError
+    false
   end
 end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -240,8 +240,24 @@ class ArtefactTest < ActiveSupport::TestCase
     artefact.redirect_url = "/foobar"
     assert artefact.valid?
 
+    artefact.redirect_url = "/foobar?an=argument"
+    assert artefact.valid?
+
+    artefact.redirect_url = "/foobar#chapter"
+    assert artefact.valid?
+
     artefact.redirect_url = "http://foo.bar/"
     refute artefact.valid?
+
+    [
+      "\jkhsdfgjkhdjskfgh//fdf#th",
+      "not a URL path",
+      "bar/baz",
+      "/foo//bar",
+    ].each do |invalid_path|
+      artefact.redirect_url = invalid_path
+      refute artefact.valid?
+    end
   end
 
   test "should translate kind into internally normalised form" do


### PR DESCRIPTION
This gem validates the `redirect_url` more strictly than `router-api` does. It doesn't allow fragments or external URLs. 

This commit makes the validations consistent between this gem and the router-api (see the [Route](https://github.com/alphagov/router-api/blob/eea3228042f7fa663ff0e40730ccf36f655e5e11/app/models/route.rb#L110) model). This means users can redirect off-site, as well as redirect to [specific guidance chapters like this one](https://www.gov.uk/guidance/self-assessment-for-agents-online-service#signing-up-for-self-assessment-for-agents). 

This was [discussed here when implementing the redirect feature](https://github.com/alphagov/govuk_content_models/pull/305#discussion_r34453252), so @boffbowsh @bradwright @alext might have thoughts?

Zendesk: https://govuk.zendesk.com/agent/tickets/1177725