### PR TITLE
Gem bump to 32.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 32.0.0
+
+- Add body and default parts to mainstream format factories
+- Remove areas field from BusinessSupportEditions and replace with area_gss_codes, which are more stable
+
 ## 31.4.0
 
 - Allow URLs with fragments in Artefact#redirect_url

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "31.4.0"
+  VERSION = "32.0.0"
 end


### PR DESCRIPTION
This takes into account changes from #350 and #351 

- Add body and default parts to mainstream format factories
- Remove areas field from BusinessSupportEditions and replace with
area_gss_codes

cc @benilovj @h-lame @tommyp 