### PR TITLE
Add attributes to two factories

### DIFF
--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -135,7 +135,7 @@ FactoryGirl.define do
   factory :video_edition, traits: [:with_body], parent: :edition, :class => 'VideoEdition' do
   end
 
-  factory :business_support_edition, :parent => :edition, :class => "BusinessSupportEdition" do
+  factory :business_support_edition, traits: [:with_body], :parent => :edition, :class => "BusinessSupportEdition" do
   end
 
   factory :guide_edition, :parent => :edition, :class => "GuideEdition" do
@@ -194,6 +194,8 @@ FactoryGirl.define do
 
   factory :licence_edition, :parent => :edition, :class => "LicenceEdition" do
     licence_identifier "AB1234"
+    licence_short_description "This is a licence short description."
+    licence_overview "This is a licence overview."
   end
 
   factory :local_service do |ls|

--- a/test/models/licence_edition_test.rb
+++ b/test/models/licence_edition_test.rb
@@ -57,7 +57,7 @@ class LicenceEditionTest < ActiveSupport::TestCase
       assert_equal 'wibble', new_version.licence_identifier
       assert new_version.valid?, "Expected clone to be valid"
     end
-    
+
     should "not validate the continuation link when blank" do
       @l.continuation_link = ""
       assert @l.valid?, "continuation link validation should not be triggered when the field is blank"
@@ -92,13 +92,13 @@ class LicenceEditionTest < ActiveSupport::TestCase
 
   context "indexable_content" do
     should "include the licence_overview, removing markup" do
-      licence = FactoryGirl.create(:licence_edition, licence_overview: "## Overview")
-      assert_equal "Overview", licence.indexable_content
+      licence = FactoryGirl.create(:licence_edition)
+      assert_includes licence.indexable_content, "This is a licence overview"
     end
 
     should "include the licence_short_description" do
-      licence = FactoryGirl.create(:licence_edition, licence_short_description: "Short desc")
-      assert_equal "Short desc", licence.indexable_content
+      licence = FactoryGirl.create(:licence_edition)
+      assert_includes licence.indexable_content, "This is a licence short description."
     end
   end
 end


### PR DESCRIPTION
Add body attribute to business support editions and licence overview & licence
short description attributes to licence editions.

This will ensure that conversion tests in publisher #428 test the presence of
the whole_body correctly when converting licence and business support editions to
something else.

cc @jamiecobbett @benilovj 