### PR TITLE
Add homepage_url to LocalAuthority

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -15,6 +15,7 @@ class LocalAuthority
   field :contact_url,        type: String
   field :contact_phone,      type: String
   field :contact_email,      type: String
+  field :homepage_url,       type: String
 
   validates_uniqueness_of :snac
   validates_presence_of   :snac, :local_directgov_id, :name, :tier

--- a/test/models/local_authority_test.rb
+++ b/test/models/local_authority_test.rb
@@ -16,7 +16,8 @@ describe LocalAuthority do
                   contact_address: ["Line one", "line two", "line three"],
                   contact_url: "http://example.gov/contact",
                   contact_phone: "0000000000",
-                  contact_email: "contact@example.gov")
+                  contact_email: "contact@example.gov",
+                  homepage_url: 'http://example.gov/')
     authority = LocalAuthority.first
     assert_equal "Example", authority.name
     assert_equal "AA00", authority.snac
@@ -26,6 +27,7 @@ describe LocalAuthority do
     assert_equal "http://example.gov/contact", authority.contact_url
     assert_equal "0000000000", authority.contact_phone
     assert_equal "contact@example.gov", authority.contact_email
+    assert_equal "http://example.gov/", authority.homepage_url
   end
 
   describe "validating local_interactions" do


### PR DESCRIPTION
We need this as step one of https://trello.com/c/td7NzjPG/261-use-local-authority-home-page-url-when-we-don-t-have-a-matching-transaction.

PRs to follow that will need this change:
* change publisher to import the homepage url (https://github.com/alphagov/publisher/pull/443)
* change frontend to use the homepage url on the "we matched your postcode to an LA but don't have a service endpoint for it" (https://github.com/alphagov/frontend/pull/914)
* change govuk_content_api to use the new homepage url and put it the api responses that include local authority details (https://github.com/alphagov/govuk_content_api/pull/237)

Is it standard practice to bump the gem version in a PR, or direct on master once merged?