### PR TITLE
Upgrade Mongo and Rails

### DIFF
--- a/app/models/business_support/business_size.rb
+++ b/app/models/business_support/business_size.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug, unique: true
+    index({slug: 1}, unique: true)
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/business_type.rb
+++ b/app/models/business_support/business_type.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug, unique: true
+    index({slug: 1}, unique: true)
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/location.rb
+++ b/app/models/business_support/location.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug, unique: true
+    index({slug: 1}, unique: true)
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/purpose.rb
+++ b/app/models/business_support/purpose.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug, unique: true
+    index({slug: 1}, unique: true)
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/sector.rb
+++ b/app/models/business_support/sector.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug, unique: true
+    index({slug: 1}, unique: true)
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/stage.rb
+++ b/app/models/business_support/stage.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug, unique: true
+    index({slug: 1}, unique: true)
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support/support_type.rb
+++ b/app/models/business_support/support_type.rb
@@ -4,7 +4,7 @@ module BusinessSupport
 
     field :name, type: String
     field :slug, type: String
-    index :slug, unique: true
+    index({slug: 1}, unique: true)
 
     validates_presence_of :name
     validates_uniqueness_of :name

--- a/app/models/business_support_edition.rb
+++ b/app/models/business_support_edition.rb
@@ -2,9 +2,6 @@
 require "edition"
 
 class BusinessSupportEdition < Edition
-
-  include Mongoid::MultiParameterAttributes
-
   field :short_description, type: String
   field :body, type: String
   field :min_value, type: Integer
@@ -40,7 +37,7 @@ class BusinessSupportEdition < Edition
   validates :min_value, :max_value, :max_employees, :numericality => {:allow_nil => true, :only_integer => true}
 
   scope :for_facets, lambda { |facets|
-    where({ "$and" => facets_criteria(facets) }).order_by([:priority, :desc], [:title, :asc])
+    where({ "$and" => facets_criteria(facets) }).order_by(priority: :desc, title: :asc)
   }
 
 

--- a/app/models/curated_list.rb
+++ b/app/models/curated_list.rb
@@ -11,7 +11,7 @@ class CuratedList
   field "slug", type: String
   has_and_belongs_to_many :artefacts, class_name: "Artefact"
 
-  index "slug"
+  index slug: 1
 
   validates :slug, presence: true, uniqueness: true, slug: true
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -36,10 +36,10 @@ class Edition
 
   # state_machine comes from Workflow
   state_machine.states.map(&:name).each do |state|
-    scope state, where(state: state)
+    scope state, lambda { where(state: state) }
   end
-  scope :archived_or_published, where(:state.in => ["archived", "published"])
-  scope :in_progress, where(:state.nin => ["archived", "published"])
+  scope :archived_or_published, lambda { where(:state.in => ["archived", "published"]) }
+  scope :in_progress, lambda { where(:state.nin => ["archived", "published"]) }
   scope :assigned_to, lambda { |user|
     if user
       where(assigned_to_id: user.id)
@@ -60,11 +60,11 @@ class Edition
   before_save :check_for_archived_artefact
   before_destroy :destroy_artefact
 
-  index "assigned_to_id"
-  index [["panopticon_id", Mongo::ASCENDING], ["version_number", Mongo::ASCENDING]], :unique => true
-  index "state"
-  index "created_at"
-  index "updated_at"
+  index assigned_to_id: 1
+  index({panopticon_id: 1, version_number: 1}, :unique => true)
+  index state: 1
+  index created_at: 1
+  index updated_at: 1
 
   alias_method :admin_list_title, :title
 
@@ -230,7 +230,7 @@ class Edition
 
   def self.find_or_create_from_panopticon_data(panopticon_id, importing_user)
     existing_publication = Edition.where(panopticon_id: panopticon_id)
-                                  .order_by([:version_number, :desc]).first
+                                  .order_by(version_number: :desc).first
     return existing_publication if existing_publication
 
     raise "Artefact not found" unless metadata = Artefact.find(panopticon_id)
@@ -245,11 +245,11 @@ class Edition
     scope = where(slug: slug)
 
     if edition.present? and edition == "latest"
-      scope.order_by(:version_number).last
+      scope.order_by(version_number: :asc).last
     elsif edition.present?
       scope.where(version_number: edition).first
     else
-      scope.where(state: "published").order(version_number: "desc").first
+      scope.where(state: "published").order(version_number: :desc).first
     end
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -38,8 +38,8 @@ class Edition
   state_machine.states.map(&:name).each do |state|
     scope state, lambda { where(state: state) }
   end
-  scope :archived_or_published, lambda { where(:state.in => ["archived", "published"]) }
-  scope :in_progress, lambda { where(:state.nin => ["archived", "published"]) }
+  scope :archived_or_published, lambda { where(:state.in => %w(archived published)) }
+  scope :in_progress, lambda { where(:state.nin => %w(archived published)) }
   scope :assigned_to, lambda { |user|
     if user
       where(assigned_to_id: user.id)
@@ -61,7 +61,7 @@ class Edition
   before_destroy :destroy_artefact
 
   index assigned_to_id: 1
-  index({panopticon_id: 1, version_number: 1}, :unique => true)
+  index({panopticon_id: 1, version_number: 1}, unique: true)
   index state: 1
   index created_at: 1
   index updated_at: 1
@@ -230,7 +230,7 @@ class Edition
 
   def self.find_or_create_from_panopticon_data(panopticon_id, importing_user)
     existing_publication = Edition.where(panopticon_id: panopticon_id)
-                                  .order_by(version_number: :desc).first
+      .order_by(version_number: :desc).first
     return existing_publication if existing_publication
 
     raise "Artefact not found" unless metadata = Artefact.find(panopticon_id)

--- a/app/models/licence_edition.rb
+++ b/app/models/licence_edition.rb
@@ -24,8 +24,11 @@ class LicenceEdition < Edition
 
   private
   def licence_identifier_unique
-    if self.class.without_state('archived').where(:licence_identifier => licence_identifier,
-                        :panopticon_id.ne => panopticon_id).any?
+    if self.class.where(
+      :state.ne => 'archived',
+      :licence_identifier => licence_identifier,
+      :panopticon_id.ne => panopticon_id
+    ).any?
       errors.add(:licence_identifier, :taken)
     end
   end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -46,7 +46,7 @@ class LocalAuthority
     else
       interactions.excludes(
         lgil_code: LocalInteraction::LGIL_CODE_PROVIDING_INFORMATION
-      ).order_by([:lgil_code, :asc]).first ||
+      ).order_by(lgil_code: :asc).first ||
       interactions.where(
         lgil_code: LocalInteraction::LGIL_CODE_PROVIDING_INFORMATION
       ).first

--- a/app/models/overview_dashboard.rb
+++ b/app/models/overview_dashboard.rb
@@ -7,7 +7,7 @@ class OverviewDashboard
   UNASSIGNED_KEY = "**UNASSIGNED**"
 
   field :dashboard_type,      type: String
-  field :result_group,        type: Integer
+  field :result_group,        type: String
   field :count,               type: Integer
   field :draft,               type: Integer
   field :amends_needed,       type: Integer

--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -7,7 +7,7 @@ class Part
   embedded_in :programme_edition
   embedded_in :business_support_edition
 
-  scope :in_order, order_by(:order, :asc)
+  scope :in_order, lambda { order_by(order: :asc) }
 
   field :order,      type: Integer
   field :title,      type: String
@@ -20,7 +20,7 @@ class Part
   validates_presence_of :title
   validates_presence_of :slug
   validates_exclusion_of :slug, in: ["video"], message: "Can not be video"
-  validates_format_of :slug, with: /^[a-z0-9\-]+$/i
+  validates_format_of :slug, with: /\A[a-z0-9\-]+\Z/i
   validates_with SafeHtml
   validates_with LinkValidator
 end

--- a/app/models/rendered_manual.rb
+++ b/app/models/rendered_manual.rb
@@ -11,7 +11,7 @@ class RenderedManual
   field :summary, type: String
   field :section_groups, type: Array
 
-  index "slug", unique: true
+  index({slug: 1}, unique: true)
 
   validates_uniqueness_of :slug
 end

--- a/app/models/simple_smart_answer_edition/node.rb
+++ b/app/models/simple_smart_answer_edition/node.rb
@@ -14,7 +14,7 @@ class SimpleSmartAnswerEdition < Edition
     field :order, type: Integer
     field :kind, type: String
 
-    default_scope order_by([:order, :asc])
+    default_scope lambda { order_by(order: :asc) }
 
     GOVSPEAK_FIELDS = [:body]
 

--- a/app/models/simple_smart_answer_edition/node/option.rb
+++ b/app/models/simple_smart_answer_edition/node/option.rb
@@ -12,7 +12,7 @@ class SimpleSmartAnswerEdition < Edition
       field :next_node, type: String
       field :order, type: Integer
 
-      default_scope order_by([:order, :asc])
+      default_scope lambda { order_by(order: :asc) }
 
       validates :label, :next_node, presence: true
       validates :slug, :format => {:with => /\A[a-z0-9-]+\z/}

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,6 @@
 require "safe_html"
 require 'tag_id_validator'
-require 'state_machine'
+require 'state_machines-mongoid'
 
 class Tag
   include Mongoid::Document
@@ -16,15 +16,13 @@ class Tag
 
   STATES = ['draft', 'live']
 
-  index :tag_id
-  index [ [:tag_id, Mongo::ASCENDING], [:tag_type, Mongo::ASCENDING] ], unique: true
-  index :tag_type
+  index tag_id: 1
+  index({tag_id: 1, tag_type: 1}, unique: true)
+  index tag_type: 1
 
   validates_presence_of :tag_id, :title, :tag_type
   validates_uniqueness_of :tag_id, scope: :tag_type
   validates_with TagIdValidator
-
-  attr_protected :state
 
   validates :state, inclusion: { in: STATES }
 

--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -37,23 +37,23 @@ class TravelAdviceEdition
     "avoid_all_travel_to_whole_country",
   ]
 
-  before_validation :populate_version_number, :on => :create
+  before_validation :populate_version_number, on: :create
 
   validates_presence_of :country_slug, :title
   validate :state_for_slug_unique
-  validates :version_number, :presence => true, :uniqueness => { :scope => :country_slug }
+  validates :version_number, presence: true, uniqueness: { scope: :country_slug }
   validate :alert_status_contains_valid_values
   validate :first_version_cant_be_minor_update
   validates_with SafeHtml
   validates_with LinkValidator
 
-  scope :published, lambda { where(:state => "published") }
+  scope :published, lambda { where(state: "published") }
 
   class << self; attr_accessor :fields_to_clone end
   @fields_to_clone = [:title, :country_slug, :overview, :alert_status, :summary, :image_id, :document_id, :synonyms]
 
   state_machine initial: :draft do
-    before_transition :draft => :published do |edition, transition|
+    before_transition draft: :published do |edition, _|
       if edition.minor_update
         previous = edition.previous_version
         edition.published_at = previous.published_at
@@ -73,12 +73,12 @@ class TravelAdviceEdition
     end
 
     event :archive do
-      transition all => :archived, :unless => :archived?
+      transition all => :archived, unless: :archived?
     end
 
     state :published do
       validate :cannot_edit_published
-      validates_presence_of :change_description, :unless => :minor_update, :message => "can't be blank on publish"
+      validates_presence_of :change_description, unless: :minor_update, message: "can't be blank on publish"
     end
     state :archived do
       validate :cannot_edit_archived
@@ -104,7 +104,7 @@ class TravelAdviceEdition
   end
 
   def build_action_as(user, action_type, comment = nil)
-    actions.build(:requester => user, :request_type => action_type, :comment => comment)
+    actions.build(requester: user, request_type: action_type, comment: comment)
   end
 
   def publish_as(user)
@@ -113,7 +113,7 @@ class TravelAdviceEdition
   end
 
   def previous_version
-    self.class.where(:country_slug => self.country_slug, :version_number.lt => self.version_number).order_by(version_number: :desc).first
+    self.class.where(country_slug: self.country_slug, :version_number.lt => self.version_number).order_by(version_number: :desc).first
   end
 
   private
@@ -121,19 +121,20 @@ class TravelAdviceEdition
   def state_for_slug_unique
     if %w(published draft).include?(self.state) and
         self.class.where(:_id.ne => id,
-                         :country_slug => country_slug,
-                         :state => state).any?
+                         country_slug: country_slug,
+                         state: state).any?
       errors.add(:state, :taken)
     end
   end
 
   def populate_version_number
     if self.version_number.nil? and ! self.country_slug.nil? and ! self.country_slug.empty?
-      if latest_edition = self.class.where(:country_slug => self.country_slug).order_by(version_number: :desc).first
-        self.version_number = latest_edition.version_number + 1
-      else
-        self.version_number = 1
-      end
+      latest_edition = self.class.where(country_slug: self.country_slug).order_by(version_number: :desc).first
+      self.version_number = if latest_edition
+                              latest_edition.version_number + 1
+                            else
+                              1
+                            end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,8 +28,10 @@ class User
   index disabled: 1
 
   scope :alphabetized, lambda { order_by(name: :asc) }
-  scope :enabled, lambda { any_of({ :disabled.exists => false },
-                         { :disabled.in => [false, nil] }) }
+  scope :enabled, lambda {
+    any_of({ :disabled.exists => false },
+           { :disabled.in => [false, nil] })
+  }
 
   def to_s
     name || email || ""

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,16 +24,12 @@ class User
   field "disabled",                type: Boolean, default: false
   field "organisation_content_id", type: String
 
-  index "uid", unique: true
-  index "disabled"
+  index({uid: 1}, unique: true)
+  index disabled: 1
 
-  # Setup accessible (or protected) attributes for your model
-  attr_accessible :email, :name, :uid
-  attr_accessible :email, :name, :uid, :permissions, as: :oauth
-
-  scope :alphabetized, order_by(name: :asc)
-  scope :enabled, any_of({ :disabled.exists => false },
-                         { :disabled.in => [false, nil] })
+  scope :alphabetized, lambda { order_by(name: :asc) }
+  scope :enabled, lambda { any_of({ :disabled.exists => false },
+                         { :disabled.in => [false, nil] }) }
 
   def to_s
     name || email || ""

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,4 +1,4 @@
-require "state_machine"
+require "state_machines-mongoid"
 
 module Workflow
   class CannotDeletePublishedPublication < RuntimeError; end
@@ -117,7 +117,7 @@ module Workflow
 
   def denormalise_users!
     new_assignee = assigned_to.try(:name)
-    set(:assignee, new_assignee) unless new_assignee == assignee
+    set(assignee: new_assignee) unless new_assignee == assignee
     update_user_action("creator",   [Action::CREATE, Action::NEW_VERSION])
     update_user_action("publisher", [Action::PUBLISH])
     update_user_action("archiver",  [Action::ARCHIVE])
@@ -133,7 +133,7 @@ module Workflow
   end
 
   def mark_as_rejected
-    self.inc(:rejected_count, 1)
+    self.inc(rejected_count: 1)
   end
 
   def previous_edition
@@ -185,7 +185,7 @@ module Workflow
         # collections, but share a model and relationships with eg actions.
         # Therefore, Panopticon might not find a user for an action.
         if action.requester
-          set(property, action.requester.name)
+          set(property => action.requester.name)
         end
       end
     end

--- a/app/traits/taggable.rb
+++ b/app/traits/taggable.rb
@@ -52,8 +52,7 @@ module Taggable
     klass.field          :tag_ids, type: Array, default: []
     klass.field          :tags, type: Array, default: []
 
-    klass.index          :tag_ids
-    klass.attr_protected :tags, :tag_ids
+    klass.index          tag_ids: 1
     klass.__send__       :private, :tag_ids=
   end
 

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,6 +1,9 @@
 test:
-  host: localhost
-  database: govuk_content_shared_test
-  logger: false
-  use_activesupport_time_zone: true
-  autocreate_indexes: true
+  clients:
+    default:
+      database: govuk_content_shared_test
+      hosts:
+        - localhost
+  options:
+    use_activesupport_time_zone: true
+    log_level: :error

--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -34,7 +34,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "webmock", "1.22.6"
   gem.add_development_dependency "shoulda-context", "1.2.1"
   gem.add_development_dependency "timecop", "0.5.9.2"
-  gem.add_development_dependency "byebug"
+  gem.add_development_dependency 'govuk-lint', '~> 0.5.1'
+  gem.add_development_dependency 'pry-byebug'
 
   # The following are added to help bundler resolve dependencies
   gem.add_development_dependency "rack", "~> 1.6.4"

--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -20,22 +20,23 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gds-sso",          "~> 11.2"
   gem.add_dependency "govspeak",         "~> 3.1"
-  # Mongoid 2.5.0 supports the newer 1.7.x and 1.8.x Mongo drivers
-  gem.add_dependency "mongoid",          "~> 2.5"
+  gem.add_dependency "mongoid",          "~> 5.1"
+  gem.add_dependency "state_machines",   "~> 0.4"
+  gem.add_dependency "state_machines-mongoid", "~> 0.1"
   gem.add_dependency "plek"
-  gem.add_dependency "state_machine"
 
-  gem.add_development_dependency "database_cleaner", "0.7.2"
-  gem.add_development_dependency "factory_girl", "3.3.0"
+  gem.add_development_dependency "database_cleaner", "1.5.1"
+  gem.add_development_dependency "factory_girl", "4.5.0"
   gem.add_development_dependency "gem_publisher", "1.2.0"
-  gem.add_development_dependency "mocha", "0.13.3"
+  gem.add_development_dependency "mocha", "1.1.0"
   gem.add_development_dependency "multi_json"
   gem.add_development_dependency "rake", "0.9.2.2"
-  gem.add_development_dependency "webmock", "1.8.7"
-  gem.add_development_dependency "shoulda-context", "1.0.0"
+  gem.add_development_dependency "webmock", "1.22.6"
+  gem.add_development_dependency "shoulda-context", "1.2.1"
   gem.add_development_dependency "timecop", "0.5.9.2"
+  gem.add_development_dependency "byebug"
 
   # The following are added to help bundler resolve dependencies
-  gem.add_development_dependency "rack", "~> 1.4.4"
-  gem.add_development_dependency "rails", "= 3.2.17"
+  gem.add_development_dependency "rack", "~> 1.6.4"
+  gem.add_development_dependency "rails", "= 4.2.5.1"
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,6 +4,9 @@ rm -f Gemfile.lock
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 export GOVUK_APP_DOMAIN=dev.gov.uk
 bundle exec rake
+
+bundle exec govuk-lint-ruby --diff --cached --format clang app config lib test
+
 if [[ -n "$PUBLISH_GEM" ]]; then
   bundle exec rake publish_gem
 fi

--- a/lib/govuk_content_models/action_processors/assign_processor.rb
+++ b/lib/govuk_content_models/action_processors/assign_processor.rb
@@ -3,7 +3,7 @@ module GovukContentModels
     class AssignProcessor < BaseProcessor
 
       def process
-        edition.set(:assigned_to_id, action_attributes[:recipient_id])
+        edition.set(assigned_to_id: action_attributes[:recipient_id])
         edition.reload
       end
 

--- a/lib/govuk_content_models/action_processors/new_version_processor.rb
+++ b/lib/govuk_content_models/action_processors/new_version_processor.rb
@@ -13,6 +13,8 @@ module GovukContentModels
         else
           edition.build_clone
         end
+
+        @edition.save(validate: false) if record_action?
       end
 
       def record_action?

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -152,19 +152,19 @@ class ArtefactTest < ActiveSupport::TestCase
         @artefact.need_id = "100045"
 
         assert_equal "100045", @artefact.need_id
-        assert_equal ["100044", "100045"], @artefact.need_ids
+        assert_equal %w(100044 100045), @artefact.need_ids
       end
 
       # this should only matter till the time we have both fields
       # need_id and need_ids. can delete this test once we unset need_id.
       should "keep need_ids unchanged when need_id is removed" do
-        @artefact.set(need_ids: ["100044", "100045"])
+        @artefact.set(need_ids: %w(100044 100045))
         @artefact.set(need_id: "100044")
 
         @artefact.need_id = nil
 
         assert_equal nil, @artefact.need_id
-        assert_equal ["100044", "100045"], @artefact.need_ids
+        assert_equal %w(100044 100045), @artefact.need_ids
       end
     end
   end
@@ -465,7 +465,7 @@ class ArtefactTest < ActiveSupport::TestCase
     artefact.update_attributes_as(user1, state: "archived")
     artefact.save!
 
-    editions.each &:reload
+    editions.each(&:reload)
     editions.each do |edition|
       assert_equal "archived", edition.state
     end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -124,7 +124,7 @@ class ArtefactTest < ActiveSupport::TestCase
     should "not validate need ids that were migrated from the singular need_id field" do
       artefact = FactoryGirl.create(:artefact)
       # simulate what happened during migration
-      artefact.set(:need_ids, ['As an employer
+      artefact.set(need_ids: ['As an employer
                                 I need to know which type of DBS check an employee needs
                                 so that I can apply for the correct one'])
 
@@ -146,8 +146,8 @@ class ArtefactTest < ActiveSupport::TestCase
       end
 
       should "append to existing need_ids when need_id is assigned" do
-        @artefact.set(:need_ids, ["100044"])
-        @artefact.set(:need_id, "100044")
+        @artefact.set(need_ids: ["100044"])
+        @artefact.set(need_id: "100044")
 
         @artefact.need_id = "100045"
 
@@ -158,8 +158,8 @@ class ArtefactTest < ActiveSupport::TestCase
       # this should only matter till the time we have both fields
       # need_id and need_ids. can delete this test once we unset need_id.
       should "keep need_ids unchanged when need_id is removed" do
-        @artefact.set(:need_ids, ["100044", "100045"])
-        @artefact.set(:need_id, "100044")
+        @artefact.set(need_ids: ["100044", "100045"])
+        @artefact.set(need_id: "100044")
 
         @artefact.need_id = nil
 
@@ -350,7 +350,7 @@ class ArtefactTest < ActiveSupport::TestCase
     artefact = FactoryGirl.create(:draft_artefact)
     edition = FactoryGirl.create(:answer_edition, panopticon_id: artefact.id)
     old_updated_at = 2.days.ago.to_time
-    edition.set(:updated_at, old_updated_at)
+    edition.set(updated_at: old_updated_at)
 
     artefact.language = "cy"
     artefact.save!

--- a/test/models/business_support_edition_test.rb
+++ b/test/models/business_support_edition_test.rb
@@ -7,7 +7,8 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
   end
 
   should "have custom fields" do
-    support = FactoryGirl.create(:business_support_edition,
+    support = FactoryGirl.create(
+      :business_support_edition,
       panopticon_id: @artefact.id,
       short_description: "The short description",
       body: "The body",
@@ -22,10 +23,10 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
       will_continue_on: "The GOVUK website",
       contact_details: "123 The Street, Townsville, UK. 07324 123456",
       priority: 2,
-      area_gss_codes: ["G123","G345","G45","G9"],
-      locations: ["scotland", "england"],
-      sectors: ["education", "manufacturing"],
-      support_types: ["grant", "loan"],
+      area_gss_codes: %w(G123 G345 G45 G9),
+      locations: %w(scotland england),
+      sectors: %w(education manufacturing),
+      support_types: %w(grant loan),
       start_date: Date.parse("1 Jan 2000"),
       end_date: Date.parse("1 Jan 2020"),
     )

--- a/test/models/business_support_edition_test.rb
+++ b/test/models/business_support_edition_test.rb
@@ -7,38 +7,34 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
   end
 
   should "have custom fields" do
-    support = FactoryGirl.create(
-      :business_support_edition,
+    support = FactoryGirl.create(:business_support_edition,
       panopticon_id: @artefact.id,
+      short_description: "The short description",
+      body: "The body",
+      eligibility: "The eligibility",
+      evaluation: "The evaluation",
+      additional_information: "The additional information",
+      min_value: 1000,
+      max_value: 3000,
+      max_employees: 2000,
+      organiser: "The business support people",
+      continuation_link: "http://www.gov.uk",
+      will_continue_on: "The GOVUK website",
+      contact_details: "123 The Street, Townsville, UK. 07324 123456",
+      priority: 2,
+      area_gss_codes: ["G123","G345","G45","G9"],
+      locations: ["scotland", "england"],
+      sectors: ["education", "manufacturing"],
+      support_types: ["grant", "loan"],
+      start_date: Date.parse("1 Jan 2000"),
+      end_date: Date.parse("1 Jan 2020"),
     )
-    support.short_description = "The short description"
-    support.body = "The body"
-    support.eligibility = "The eligibility"
-    support.evaluation = "The evaluation"
-    support.additional_information = "The additional information"
-    support.min_value = 1000
-    support.max_value = 3000
-    support.max_employees = 2000
-    support.organiser = "The business support people"
-    support.continuation_link = "http://www.gov.uk"
-    support.will_continue_on = "The GOVUK website"
-    support.contact_details = "123 The Street, Townsville, UK. 07324 123456"
 
-    support.priority = 2
-    support.area_gss_codes = ["G123","G345","G45","G9"]
     support.business_sizes << "up-to-249"
     support.business_types << "charity"
-    support.locations = ["scotland", "england"]
     support.purposes << "making-the-most-of-the-internet"
-    support.sectors = ["education", "manufacturing"]
     support.stages << "start-up"
-    support.support_types = ["grant", "loan"]
-    support.start_date = Date.parse("1 Jan 2000")
-    support.end_date = Date.parse("1 Jan 2020")
 
-    support.safely.save!
-
-    support = BusinessSupportEdition.first
     assert_equal "The short description", support.short_description
     assert_equal "The body", support.body
     assert_equal "The eligibility", support.eligibility

--- a/test/models/campaign_edition_test.rb
+++ b/test/models/campaign_edition_test.rb
@@ -6,7 +6,8 @@ class CampaignEditionTest < ActiveSupport::TestCase
   end
 
   should "have correct extra fields" do
-    c = FactoryGirl.create(:campaign_edition,
+    c = FactoryGirl.create(
+      :campaign_edition,
       panopticon_id: @artefact.id,
       body: "Start all the campaigns!",
       large_image_id: "large-image-id-from-the-asset-manager",

--- a/test/models/campaign_edition_test.rb
+++ b/test/models/campaign_edition_test.rb
@@ -6,18 +6,18 @@ class CampaignEditionTest < ActiveSupport::TestCase
   end
 
   should "have correct extra fields" do
-    c = FactoryGirl.build(:campaign_edition, :panopticon_id => @artefact.id)
-    c.body = "Start all the campaigns!"
-    c.large_image_id = "large-image-id-from-the-asset-manager"
-    c.medium_image_id = "medium-image-id-from-the-asset-manager"
-    c.small_image_id = "small-image-id-from-the-asset-manager"
-    c.organisation_formatted_name = "Driver & Vehicle\nLicensing\nAgency"
-    c.organisation_url = "/government/organisations/driver-and-vehicle-licensing-agency"
-    c.organisation_brand_colour = "department-for-transport"
-    c.organisation_crest = "single-identity"
-    c.safely.save!
+    c = FactoryGirl.create(:campaign_edition,
+      panopticon_id: @artefact.id,
+      body: "Start all the campaigns!",
+      large_image_id: "large-image-id-from-the-asset-manager",
+      medium_image_id: "medium-image-id-from-the-asset-manager",
+      small_image_id: "small-image-id-from-the-asset-manager",
+      organisation_formatted_name: "Driver & Vehicle\nLicensing\nAgency",
+      organisation_url: "/government/organisations/driver-and-vehicle-licensing-agency",
+      organisation_brand_colour: "department-for-transport",
+      organisation_crest: "single-identity",
+    )
 
-    c = CampaignEdition.first
     assert_equal "Start all the campaigns!", c.body
     assert_equal "large-image-id-from-the-asset-manager", c.large_image_id
     assert_equal "medium-image-id-from-the-asset-manager", c.medium_image_id

--- a/test/models/downtime_test.rb
+++ b/test/models/downtime_test.rb
@@ -84,7 +84,7 @@ class DowntimeTest < ActiveSupport::TestCase
       Timecop.freeze(Time.zone.now + 10) do
         downtime = FactoryGirl.build(:downtime)
 
-        downtime.end_time = Time.zone.now
+        downtime.end_time = Time.zone.now - 1.minute
         refute downtime.publicise?
       end
     end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1049,7 +1049,7 @@ class EditionTest < ActiveSupport::TestCase
       ed2.version_number = ed1.version_number
 
       assert_raises Mongo::Error::OperationFailure do
-        ed2.save! :validate => false
+        ed2.save! validate: false
       end
     end
   end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -24,8 +24,8 @@ class EditionTest < ActiveSupport::TestCase
 
   def template_published_answer(version_number = 1)
     answer = template_answer(version_number)
-    answer.publish
-    answer.save
+    answer.publish!
+    answer.save!
     answer
   end
 
@@ -103,7 +103,7 @@ class EditionTest < ActiveSupport::TestCase
       edition.body += "some update"
 
       refute edition.valid?
-      assert_include edition.errors.full_messages, %q<Body ["Don't include hover text in links. Delete the text in quotation marks eg \\"This appears when you hover over the link.\\""]>
+      assert_includes edition.errors.full_messages, %q<Body ["Don't include hover text in links. Delete the text in quotation marks eg \\"This appears when you hover over the link.\\""]>
     end
 
     should "allow archiving an edition with invalid links" do
@@ -723,6 +723,8 @@ class EditionTest < ActiveSupport::TestCase
 
     second_edition = edition.build_clone
     second_edition.state = "ready"
+    second_edition.save!
+
     publish(user, second_edition, "Second publication")
 
     # simulate link validation errors in published edition
@@ -732,6 +734,8 @@ class EditionTest < ActiveSupport::TestCase
     # fix link validation error in cloned edition by appending a '/' to the relative url
     third_edition.parts.first.body = "[register your vehicle](/registering-an-imported-vehicle)"
     third_edition.state = "ready"
+    third_edition.save!
+
     publish(user, third_edition, "Third publication")
 
     edition.reload
@@ -854,7 +858,7 @@ class EditionTest < ActiveSupport::TestCase
   test "user should not be able to review an edition they requested review for" do
     user = User.create(name: "Mary")
 
-    edition = ProgrammeEdition.new(title: "Childcare", slug: "childcare", panopticon_id: @artefact.id)
+    edition = ProgrammeEdition.create(title: "Childcare", slug: "childcare", panopticon_id: @artefact.id)
     assert edition.can_request_review?
     request_review(user, edition)
     refute request_amendments(user, edition)
@@ -1044,8 +1048,8 @@ class EditionTest < ActiveSupport::TestCase
       ed2 = FactoryGirl.build(:edition, :panopticon_id => @artefact.id)
       ed2.version_number = ed1.version_number
 
-      assert_raises Mongo::OperationFailure do
-        ed2.safely.save! :validate => false
+      assert_raises Mongo::Error::OperationFailure do
+        ed2.save! :validate => false
       end
     end
   end
@@ -1195,7 +1199,7 @@ class EditionTest < ActiveSupport::TestCase
                                                      state: 'published')
       edition2 = edition1.build_clone
 
-      assert_equal edition1.updated_at, edition2.public_updated_at
+      assert_in_delta edition1.updated_at, edition2.public_updated_at, 1.second
     end
 
     should 'return the timestamp of the first published edition when there are no major updates' do
@@ -1209,8 +1213,8 @@ class EditionTest < ActiveSupport::TestCase
       end
       edition1.update_attributes!(state: 'archived', major_change: false)
 
-      assert_equal edition1.updated_at, edition2.public_updated_at
-      assert_not_equal edition2.updated_at, edition2.public_updated_at
+      assert_in_delta edition1.updated_at, edition2.public_updated_at, 1.second
+      assert_not_in_delta edition2.updated_at, edition2.public_updated_at, 1.second
     end
 
     should 'return nil if there are no major updates and no published editions' do

--- a/test/models/help_page_edition_test.rb
+++ b/test/models/help_page_edition_test.rb
@@ -2,11 +2,12 @@ require "test_helper"
 
 class HelpPageEditionTest < ActiveSupport::TestCase
   setup do
-    @artefact = FactoryGirl.create(:artefact, :kind => 'help_page', :slug => "help/foo")
+    @artefact = FactoryGirl.create(:artefact, kind: 'help_page', slug: "help/foo")
   end
 
   should "have correct extra fields" do
-    h = FactoryGirl.create(:help_page_edition,
+    h = FactoryGirl.create(
+      :help_page_edition,
       panopticon_id: @artefact.id,
       body: "I'm a help page.",
     )
@@ -20,17 +21,21 @@ class HelpPageEditionTest < ActiveSupport::TestCase
   end
 
   should "return the body as whole_body" do
-    h = FactoryGirl.build(:help_page_edition,
-                          :panopticon_id => @artefact.id,
-                          :body => "Something")
+    h = FactoryGirl.build(
+      :help_page_edition,
+      panopticon_id: @artefact.id,
+      body: "Something",
+    )
     assert_equal h.body, h.whole_body
   end
 
   should "clone extra fields when cloning edition" do
-    help_page = FactoryGirl.create(:help_page_edition,
-                               :panopticon_id => @artefact.id,
-                               :state => "published",
-                               :body => "I'm very helpful")
+    help_page = FactoryGirl.create(
+      :help_page_edition,
+      panopticon_id: @artefact.id,
+      state: "published",
+      body: "I'm very helpful",
+    )
 
     new_help_page = help_page.build_clone
     assert_equal help_page.body, new_help_page.body

--- a/test/models/help_page_edition_test.rb
+++ b/test/models/help_page_edition_test.rb
@@ -6,11 +6,11 @@ class HelpPageEditionTest < ActiveSupport::TestCase
   end
 
   should "have correct extra fields" do
-    h = FactoryGirl.build(:help_page_edition, :panopticon_id => @artefact.id)
-    h.body = "I'm a help page."
-    h.safely.save!
+    h = FactoryGirl.create(:help_page_edition,
+      panopticon_id: @artefact.id,
+      body: "I'm a help page.",
+    )
 
-    h = HelpPageEdition.first
     assert_equal "I'm a help page.", h.body
   end
 

--- a/test/models/licence_edition_test.rb
+++ b/test/models/licence_edition_test.rb
@@ -6,7 +6,8 @@ class LicenceEditionTest < ActiveSupport::TestCase
   end
 
   should "have correct extra fields" do
-    l = FactoryGirl.create(:licence_edition,
+    l = FactoryGirl.create(
+      :licence_edition,
       panopticon_id: @artefact.id,
       licence_identifier: "AB1234",
       licence_short_description: "Short description of licence",

--- a/test/models/licence_edition_test.rb
+++ b/test/models/licence_edition_test.rb
@@ -6,15 +6,15 @@ class LicenceEditionTest < ActiveSupport::TestCase
   end
 
   should "have correct extra fields" do
-    l = FactoryGirl.build(:licence_edition, panopticon_id: @artefact.id)
-    l.licence_identifier = "AB1234"
-    l.licence_short_description = "Short description of licence"
-    l.licence_overview = "Markdown overview of licence..."
-    l.will_continue_on = "The HMRC website"
-    l.continuation_link = "http://www.hmrc.gov.uk"
-    l.safely.save!
+    l = FactoryGirl.create(:licence_edition,
+      panopticon_id: @artefact.id,
+      licence_identifier: "AB1234",
+      licence_short_description: "Short description of licence",
+      licence_overview: "Markdown overview of licence...",
+      will_continue_on: "The HMRC website",
+      continuation_link: "http://www.hmrc.gov.uk"
+    )
 
-    l = LicenceEdition.first
     assert_equal "AB1234", l.licence_identifier
     assert_equal "Short description of licence", l.licence_short_description
     assert_equal "Markdown overview of licence...", l.licence_overview

--- a/test/models/local_transaction_edition_test.rb
+++ b/test/models/local_transaction_edition_test.rb
@@ -3,35 +3,39 @@ require "govuk_content_models/test_helpers/local_services"
 
 class LocalTransactionEditionTest < ActiveSupport::TestCase
   include LocalServicesHelper
+  BINS = 1
+  HOUSING_BENEFIT = 2
+  NONEXISTENT = 999
+
   def setup
     @artefact = FactoryGirl.create(:artefact)
   end
 
   test "should report that an authority provides a service" do
     bins_transaction = LocalTransactionEdition.new(
-      lgsl_code:     "bins",
+      lgsl_code:     BINS,
       title:         "Transaction",
       slug:          "slug",
       panopticon_id: @artefact.id
     )
-    county_council = make_authority_providing("bins")
+    county_council = make_authority_providing(BINS)
     assert bins_transaction.service_provided_by?(county_council.snac)
   end
 
   test "should report that an authority does not provide a service" do
     bins_transaction = LocalTransactionEdition.new(
-      lgsl_code:     "bins",
+      lgsl_code:     BINS,
       title:         "Transaction",
       slug:          "slug",
       panopticon_id: @artefact.id
     )
-    county_council = make_authority_providing("housing-benefit")
+    county_council = make_authority_providing(HOUSING_BENEFIT)
     refute bins_transaction.service_provided_by?(county_council.snac)
   end
 
   test "should be a transaction search format" do
     bins_transaction = LocalTransactionEdition.new(
-      lgsl_code:     "bins",
+      lgsl_code:     BINS,
       title:         "Transaction",
       slug:          "slug",
       panopticon_id: @artefact.id
@@ -41,9 +45,9 @@ class LocalTransactionEditionTest < ActiveSupport::TestCase
 
 
   test "should validate on save that a LocalService exists for that lgsl_code" do
-    s = LocalService.create!(lgsl_code: "bins", providing_tier: %w{county unitary})
+    s = LocalService.create!(lgsl_code: BINS, providing_tier: %w{county unitary})
 
-    lt = LocalTransactionEdition.new(lgsl_code: "nonexistent", title: "Foo", slug: "foo", panopticon_id: @artefact.id)
+    lt = LocalTransactionEdition.new(lgsl_code: NONEXISTENT, title: "Foo", slug: "foo", panopticon_id: @artefact.id)
     lt.save
     assert !lt.valid?
 

--- a/test/models/prerendered_entity_tests.rb
+++ b/test/models/prerendered_entity_tests.rb
@@ -15,11 +15,11 @@ module PrerenderedEntityTests
 
   def test_create_or_update_by_slug
     slug = "a-slug"
-    original_body = "Original body"
+    original_title = "Original title"
 
     version1_attrs= {
       slug: slug,
-      body: original_body,
+      title: original_title,
     }
 
     created = model_class.create_or_update_by_slug!(version1_attrs)
@@ -28,13 +28,13 @@ module PrerenderedEntityTests
     assert created.persisted?
 
     version2_attrs = version1_attrs.merge(
-      body: "Updated body",
+      title: "Updated title",
     )
 
     version2 = model_class.create_or_update_by_slug!(version2_attrs)
 
     assert version2.persisted?
-    assert_equal "Updated body", version2.body
+    assert_equal "Updated title", version2.title
   end
 
   def test_find_by_slug

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -156,13 +156,6 @@ class TagTest < ActiveSupport::TestCase
       assert_equal 'live', tag.state
     end
 
-    should "not mass-assign the state attribute" do
-      tag = Tag.create(@atts.merge(state: 'live'))
-      tag.reload
-
-      refute_equal 'live', tag.state
-    end
-
     should "not be created in another state" do
       tag = Tag.new(@atts)
       tag.state = 'foo'
@@ -187,7 +180,7 @@ class TagTest < ActiveSupport::TestCase
       tag.publish!
       tag.reload
 
-      assert_raises StateMachine::InvalidTransition do
+      assert_raises StateMachines::InvalidTransition do
         tag.publish!
       end
     end

--- a/test/models/travel_advice_edition_test.rb
+++ b/test/models/travel_advice_edition_test.rb
@@ -19,7 +19,7 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
     ed.change_description = "Some things"
     ed.synonyms = ["Foo", "Bar"]
     ed.parts.build(:title => "Part One", :slug => "one")
-    ed.safely.save!
+    ed.save!
 
     ed = TravelAdviceEdition.first
     assert_equal "Travel advice for Aruba", ed.title
@@ -319,6 +319,7 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
       @published = FactoryGirl.create(:published_travel_advice_edition, :country_slug => 'aruba',
                                       :published_at => 3.days.ago, :change_description => 'Stuff changed')
       @ed = FactoryGirl.create(:travel_advice_edition, :country_slug => 'aruba')
+      @published.reload
     end
 
     should "publish the edition and archive related editions" do
@@ -358,6 +359,7 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
                                       :published_at => 3.days.ago, :change_description => 'Stuff changed')
       @published.reviewed_at = 2.days.ago
       @published.save!
+      @published.reload
 
       Timecop.freeze(1.days.ago) do
         # this is done to make sure there's a significant difference in time

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -64,7 +64,7 @@ class UserTest < ActiveSupport::TestCase
   test "should find and update the user with oauth params" do
     attributes = {uid: "1234abcd", name: "Old", email: "old@m.com",
         permissions: ["everything"]}
-    User.create!(attributes, without_protection: true)
+    User.create!(attributes)
     auth_hash = {
       "uid" => "1234abcd",
       "info" => {

--- a/test/models/video_edition_test.rb
+++ b/test/models/video_edition_test.rb
@@ -11,7 +11,7 @@ class VideoEditionTest < ActiveSupport::TestCase
     v.video_summary = "Coke smoothie"
     v.body = "Description of video"
     v.caption_file_id = 'file-to-an-asset-of-the-caption-file'
-    v.safely.save!
+    v.save!
 
     v = VideoEdition.first
     assert_equal "http://www.youtube.com/watch?v=qySFp3qnVmM", v.video_url

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -6,8 +6,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   def template_users
-    user = User.create(name: "Bob")
-    other_user = User.create(name: "James")
+    user = FactoryGirl.create(:user, name: "Bob")
+    other_user = FactoryGirl.create(:user, name: "James")
     return user, other_user
   end
 
@@ -24,8 +24,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   def publisher_and_guide
-    user = User.create(name: "Ben")
-    other_user = User.create(name: "James")
+    user = FactoryGirl.create(:user, name: "Ben")
+    other_user = FactoryGirl.create(:user, name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: @artefact.id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -40,8 +40,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   def template_user_and_published_transaction
-    user = User.create(name: "Ben")
-    other_user = User.create(name: "James")
+    user = FactoryGirl.create(:user, name: "Ben")
+    other_user = FactoryGirl.create(:user, name: "James")
 
     transaction = user.create_edition(:transaction, title: "My title", slug: "my-title", panopticon_id: @artefact.id, need_to_know: "Credit card required")
     transaction.save
@@ -110,7 +110,7 @@ class WorkflowTest < ActiveSupport::TestCase
 
   test "a guide should be marked as having reviewables if requested for review" do
     guide = template_guide
-    user = User.create(name:"Ben")
+    user = FactoryGirl.create(:user, name:"Ben")
     refute guide.in_review?
     assert_nil guide.review_requested_at
 
@@ -131,8 +131,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "guide workflow" do
-    user = User.create(name: "Ben")
-    other_user = User.create(name: "James")
+    user = FactoryGirl.create(:user, name: "Ben")
+    other_user = FactoryGirl.create(:user, name: "James")
 
     guide = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: @artefact.id)
     edition = guide
@@ -150,8 +150,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "when fact check has been initiated it can be skipped" do
-    user = User.create(name: "Ben")
-    other_user = User.create(name: "James")
+    user = FactoryGirl.create(:user, name: "Ben")
+    other_user = FactoryGirl.create(:user, name: "James")
 
     edition = user.create_edition(:guide, panopticon_id: @artefact.id, overview: "My Overview", title: "My Title", slug: "my-title")
 
@@ -167,8 +167,8 @@ class WorkflowTest < ActiveSupport::TestCase
 
   # until we improve the validation to produce few or no false positives
   test "when processing fact check, it is not validated" do
-    user = User.create(name: "Ben")
-    other_user = User.create(name: "James")
+    user = FactoryGirl.create(:user, name: "Ben")
+    other_user = FactoryGirl.create(:user, name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -182,8 +182,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "fact_check_received can go back to out for fact_check" do
-    user = User.create(name: "Ben")
-    other_user = User.create(name: "James")
+    user = FactoryGirl.create(:user, name: "Ben")
+    other_user = FactoryGirl.create(:user, name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -198,8 +198,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "when processing fact check, an edition can request for amendments" do
-    user = User.create(name: "Ben")
-    other_user = User.create(name: "James")
+    user = FactoryGirl.create(:user, name: "Ben")
+    other_user = FactoryGirl.create(:user, name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -214,9 +214,9 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "ready items may require further amendments" do
-    user = User.create(name: "Ben")
-    other_user = User.create(name: "James")
-    another_user = User.create(name: "Fiona")
+    user = FactoryGirl.create(:user, name: "Ben")
+    other_user = FactoryGirl.create(:user, name: "James")
+    another_user = FactoryGirl.create(:user, name: "Fiona")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -234,8 +234,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "check counting reviews" do
-    user = User.create(name: "Ben")
-    other_user = User.create(name: "James")
+    user = FactoryGirl.create(:user, name: "Ben")
+    other_user = FactoryGirl.create(:user, name: "James")
 
     guide = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: @artefact.id)
     edition = guide
@@ -254,7 +254,7 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "user should not be able to review a guide they requested review for" do
-    user = User.create(name: "Ben")
+    user = FactoryGirl.create(:user, name: "Ben")
 
     guide = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: @artefact.id)
     edition = guide
@@ -265,7 +265,7 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "user should not be able to okay a guide they requested review for" do
-    user = User.create(name: "Ben")
+    user = FactoryGirl.create(:user, name: "Ben")
 
     guide = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: @artefact.id)
     edition = guide
@@ -368,7 +368,7 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "important_note returns last non-resolved important note" do
-    user = User.create(name: "Ben")
+    user = FactoryGirl.create(:user, name: "Ben")
     edition = template_guide
     user.record_note(edition, 'this is an important note', Action::IMPORTANT_NOTE)
     request_review(user, edition)
@@ -396,7 +396,7 @@ class WorkflowTest < ActiveSupport::TestCase
 
     should "return the new edition" do
       new_version = @user.new_version(@edition)
-      assert_include new_version.previous_siblings.to_a, @edition
+      assert_includes new_version.previous_siblings.to_a, @edition
     end
 
     context "creating an edition of a different type" do

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -110,7 +110,7 @@ class WorkflowTest < ActiveSupport::TestCase
 
   test "a guide should be marked as having reviewables if requested for review" do
     guide = template_guide
-    user = FactoryGirl.create(:user, name:"Ben")
+    user = FactoryGirl.create(:user, name: "Ben")
     refute guide.in_review?
     assert_nil guide.review_requested_at
 
@@ -216,7 +216,7 @@ class WorkflowTest < ActiveSupport::TestCase
   test "ready items may require further amendments" do
     user = FactoryGirl.create(:user, name: "Ben")
     other_user = FactoryGirl.create(:user, name: "James")
-    another_user = FactoryGirl.create(:user, name: "Fiona")
+    FactoryGirl.create(:user, name: "Fiona")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryGirl.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,19 +5,22 @@ require "bundler/setup"
 require "active_support/test_case"
 require "shoulda/context"
 require "minitest/autorun"
+require "mocha/mini_test"
 require "mongoid"
 require "govuk_content_models/require_all"
 require "database_cleaner"
 require "gds_api/test_helpers/panopticon"
-require "webmock/test_unit"
+require "webmock/minitest"
 require "govuk_content_models/test_helpers/factories"
 require 'govuk_content_models/test_helpers/action_processor_helpers'
 require "timecop"
+require "byebug"
 
 # The models depend on a zone being set, so tests will fail if we don't
 Time.zone = "London"
 
 Mongoid.load! File.expand_path("../../config/mongoid.yml", __FILE__)
+Mongoid::Tasks::Database.create_indexes
 WebMock.disable_net_connect!
 
 DatabaseCleaner.strategy = :truncation


### PR DESCRIPTION
Upgrade to Mongo 5 and Rails 4.2, which unblocks projects which use this gem from upgrading to latest Rails.

In order not to break the existing apps, this PR is for merging into a branch; upgraded apps can point to the merged branch until they are all done, at which point we can release a new version.

The bulk of this work was done by @elliotcm.