### PR TITLE
Save artefact automatic actions with save_as_task method

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -318,6 +318,17 @@ class Artefact
     save(options)
   end
 
+  # We should use this method when performing save actions from rake tasks,
+  # message queue consumer or any other performed tasks that have no user associated
+  # as we are still interested to know what triggered the action.
+  def save_as_task(task_name, options = {})
+    default_action = new_record? ? "create" : "update"
+    action_type = options.delete(:action_type) || default_action
+
+    record_action(action_type, task_name: task_name)
+    save(options)
+  end
+
   def record_create_action
     record_action "create"
   end
@@ -328,14 +339,21 @@ class Artefact
 
   def record_action(action_type, options={})
     user = options[:user]
+    task_name = options[:task_name]
     current_snapshot = snapshot
-    last_snapshot = actions.last ? actions.last.snapshot : nil
+    last_snapshot = actions.last.snapshot if actions.last
+
     unless current_snapshot == last_snapshot
-      new_action = actions.build(
-        user: user,
+
+      attributes = {
         action_type: action_type,
-        snapshot: current_snapshot
-      )
+        snapshot: current_snapshot,
+      }
+
+      attributes.merge!(user: user) if user
+      attributes.merge!(task_performed_by: task_name) if task_name
+
+      new_action = actions.build(attributes)
       # Mongoid will not fire creation callbacks on embedded documents, so we
       # need to trigger this manually. There is a `cascade_callbacks` option on
       # `embeds_many`, but it doesn't appear to trigger creation events on

--- a/app/models/artefact_action.rb
+++ b/app/models/artefact_action.rb
@@ -6,6 +6,7 @@ class ArtefactAction
 
   field "action_type", type: String
   field "snapshot", type: Hash
+  field "task_performed_by", type: String
 
   embedded_in :artefact
 

--- a/test/models/artefact_action_test.rb
+++ b/test/models/artefact_action_test.rb
@@ -91,6 +91,18 @@ class ArtefactActionTest < ActiveSupport::TestCase
     )
   end
 
+  test "saving a task should record the task action" do
+    @artefact.description = "Updated automatically"
+    @artefact.save_as_task('TaggingUpdater')
+    @artefact.reload
+
+    assert_equal 2, @artefact.actions.size
+    assert_equal ["create", "update"], @artefact.actions.map(&:action_type)
+
+    assert_equal 'TaggingUpdater', @artefact.actions.last.task_performed_by
+    assert_equal nil, @artefact.actions.last.user
+  end
+
   test "saving as a user should record a user action" do
     user = FactoryGirl.create :user
     updates = {description: "Shiny shiny description"}

--- a/test/models/artefact_action_test.rb
+++ b/test/models/artefact_action_test.rb
@@ -39,86 +39,84 @@ class ArtefactActionTest < ActiveSupport::TestCase
     }
   end
 
-  test "a new artefact should have a create action" do
-    a = Artefact.create!(base_fields)
-    a.reload
+  def setup
+    @artefact = Artefact.create!(base_fields)
+  end
 
-    assert_equal 1, a.actions.size
-    action = a.actions.first
+  test "a new artefact should have a create action" do
+    @artefact.reload
+
+    assert_equal 1, @artefact.actions.size
+    action = @artefact.actions.first
     assert_equal "create", action[:action_type]
     assert_equal merge_attributes(DEFAULTS, base_fields), action.snapshot
     assert action.created_at, "Action has no creation timestamp"
   end
 
   test "an updated artefact should have two actions" do
-    a = Artefact.create!(base_fields)
-    a.description = "An artefact of shining wonderment."
-    a.save!
-    a.reload
+    @artefact.description = "An artefact of shining wonderment."
+    @artefact.save!
+    @artefact.reload
 
-    assert_equal 2, a.actions.size
-    assert_equal ["create", "update"], a.actions.map(&:action_type)
+    assert_equal 2, @artefact.actions.size
+    assert_equal ["create", "update"], @artefact.actions.map(&:action_type)
     create_snapshot = merge_attributes(DEFAULTS, base_fields)
-    update_snapshot = create_snapshot.merge("description" => a.description)
-    assert_equal create_snapshot, a.actions[0].snapshot
-    assert_equal update_snapshot, a.actions[1].snapshot
-    a.actions.each do |action|
+    update_snapshot = create_snapshot.merge("description" => @artefact.description)
+    assert_equal create_snapshot, @artefact.actions[0].snapshot
+    assert_equal update_snapshot, @artefact.actions[1].snapshot
+    @artefact.actions.each do |action|
       assert action.created_at, "Action has no creation timestamp"
     end
   end
 
   test "saving with no tracked changes will not create a new snapshot" do
-    a = Artefact.create!(base_fields)
-    a.updated_at = Time.zone.now + 5.minutes
-    a.save!
-    assert_equal 1, a.actions.size
+    @artefact.updated_at = Time.zone.now + 5.minutes
+    @artefact.save!
+    assert_equal 1, @artefact.actions.size
   end
 
   test "updating attributes as a user should record a user action" do
-    a = Artefact.create!(base_fields)
     user = FactoryGirl.create :user
     updates = {description: "Shiny shiny description"}
-    a.update_attributes_as user, updates
-    a.reload
+    @artefact.update_attributes_as user, updates
+    @artefact.reload
 
-    assert_equal "Shiny shiny description", a.description
-    assert_equal 2, a.actions.size
-    assert_equal ["create", "update"], a.actions.map(&:action_type)
-    assert_equal user, a.actions.last.user
+    assert_equal "Shiny shiny description", @artefact.description
+    assert_equal 2, @artefact.actions.size
+    assert_equal ["create", "update"], @artefact.actions.map(&:action_type)
+    assert_equal user, @artefact.actions.last.user
     assert_equal(
         merge_attributes(DEFAULTS, base_fields, updates),
-        a.actions.last.snapshot
+        @artefact.actions.last.snapshot
     )
   end
 
   test "saving as a user should record a user action" do
-    a = Artefact.create!(base_fields)
     user = FactoryGirl.create :user
     updates = {description: "Shiny shiny description"}
-    a.description = updates[:description]
-    a.save_as user
-    a.reload
+    @artefact.description = updates[:description]
+    @artefact.save_as user
+    @artefact.reload
 
-    assert_equal "Shiny shiny description", a.description
-    assert_equal 2, a.actions.size
-    assert_equal ["create", "update"], a.actions.map(&:action_type)
-    assert_equal user, a.actions.last.user
+    assert_equal "Shiny shiny description", @artefact.description
+    assert_equal 2, @artefact.actions.size
+    assert_equal ["create", "update"], @artefact.actions.map(&:action_type)
+    assert_equal user, @artefact.actions.last.user
     assert_equal(
         merge_attributes(DEFAULTS, base_fields, updates),
-        a.actions.last.snapshot
+        @artefact.actions.last.snapshot
     )
   end
 
   test "saving as a user with an action type" do
-    a = Artefact.create!(base_fields)
     user = FactoryGirl.create :user
     updates = {description: "Shiny shiny description"}
-    a.description = updates[:description]
-    a.save_as user, action_type: "awesome"
-    a.reload
+    @artefact.description = updates[:description]
+    @artefact.save_as user, action_type: "awesome"
+    @artefact.reload
 
-    assert_equal user, a.actions.last.user
-    assert_equal "awesome", a.actions.last.action_type
+    assert_equal user, @artefact.actions.last.user
+    assert_equal "awesome", @artefact.actions.last.action_type
   end
 
 end


### PR DESCRIPTION
Given that during the incident in 2016-02-14 it was not clear what meant "An unknown user".
When an artefact action has no user it means it was updated by one of the tasks, in panopticon it would be one of these three:

- TaggingUpdater
- OrganisationSlugChanger
- rake task "Move content to new topics"

In order to know which one, we have agreed to add a new field in ArtefactAction called "task_performed_by" that receives a string with the name of the automatic task.

This will facilitate future debugging and more visibility to developers if future incidents happen.

**Part of:** https://trello.com/c/RWkPMkJK/533-incident-investigation-why-does-panopticon-history-show-updates-from-unknown-user