### PR TITLE
Use save! inside Artefact#save_as_task

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -321,12 +321,12 @@ class Artefact
   # We should use this method when performing save actions from rake tasks,
   # message queue consumer or any other performed tasks that have no user associated
   # as we are still interested to know what triggered the action.
-  def save_as_task(task_name, options = {})
+  def save_as_task!(task_name, options = {})
     default_action = new_record? ? "create" : "update"
     action_type = options.delete(:action_type) || default_action
 
     record_action(action_type, task_name: task_name)
-    save(options)
+    save!(options)
   end
 
   def record_create_action

--- a/test/models/artefact_action_test.rb
+++ b/test/models/artefact_action_test.rb
@@ -93,7 +93,7 @@ class ArtefactActionTest < ActiveSupport::TestCase
 
   test "saving a task should record the task action" do
     @artefact.description = "Updated automatically"
-    @artefact.save_as_task('TaggingUpdater')
+    @artefact.save_as_task!('TaggingUpdater')
     @artefact.reload
 
     assert_equal 2, @artefact.actions.size


### PR DESCRIPTION
`save_as_task` was created to replace `save!`, as example of that you
can refer to:
https://github.com/alphagov/panopticon/pull/329/files#diff-a16076a539fa7fef323704a5f9404f78L53

This commit aims to bring back that consistency.

Part of: https://trello.com/c/RWkPMkJK