### PR TITLE
Fix some ordering issues

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -80,11 +80,11 @@ class Edition
   end
 
   def previous_siblings
-    siblings.where(:version_number.lt => version_number)
+    siblings.where(:version_number.lt => version_number).order(version_number: "asc")
   end
 
   def subsequent_siblings
-    siblings.where(:version_number.gt => version_number)
+    siblings.where(:version_number.gt => version_number).order(version_number: "asc")
   end
 
   def latest_edition?

--- a/app/models/parted.rb
+++ b/app/models/parted.rb
@@ -28,7 +28,7 @@ module Parted
   end
 
   def whole_body
-    self.parts.map {|i| %Q{\# #{i.title}\n\n#{i.body}} }.join("\n\n")
+    self.parts.in_order.map { |i| %(\# #{i.title}\n\n#{i.body}) }.join("\n\n")
   end
 
   private

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -97,12 +97,17 @@ FactoryGirl.define do
         a = create(:artefact)
         a.id
       }
+    transient do
+      version_number nil
+    end
 
     sequence(:slug) { |n| "slug-#{n}" }
     sequence(:title) { |n| "A key answer to your question #{n}" }
 
-    after :build do |ed|
-      if previous = ed.series.order(version_number: "desc").first
+    after :build do |ed, evaluator|
+      if !evaluator.version_number.nil?
+        ed.version_number = evaluator.version_number
+      elsif (previous = ed.series.order(version_number: "desc").first)
         ed.version_number = previous.version_number + 1
       end
     end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -85,6 +85,16 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [g1], g3.previous_siblings.to_a
   end
 
+  test "subsequent and previous siblings are in order" do
+    g4 = FactoryGirl.create(:guide_edition, panopticon_id: @artefact.id, version_number: 4)
+    g2 = FactoryGirl.create(:guide_edition, panopticon_id: @artefact.id, version_number: 2)
+    g1 = FactoryGirl.create(:guide_edition, panopticon_id: @artefact.id, version_number: 1)
+    g3 = FactoryGirl.create(:guide_edition, panopticon_id: @artefact.id, version_number: 3)
+
+    assert_equal [g2, g3, g4], g1.subsequent_siblings.to_a
+    assert_equal [g1, g2, g3], g4.previous_siblings.to_a
+  end
+
   test "A programme should have default parts" do
     programme = FactoryGirl.create(:programme_edition, panopticon_id: @artefact.id)
     assert_equal programme.parts.count, ProgrammeEdition::DEFAULT_PARTS.length

--- a/test/models/parted_test.rb
+++ b/test/models/parted_test.rb
@@ -15,4 +15,12 @@ class PartedTest < ActiveSupport::TestCase
     assert_equal({slug: ["can't be blank", "is invalid"]}, edition.errors[:parts][0]['54c10d4d759b743528000011:2'])
     assert_equal 2, edition.errors[:parts][0].length
   end
+
+  test "#whole_body returns ordered parts" do
+    edition = FactoryGirl.create(:guide_edition)
+    edition.parts.build(_id: '54c10d4d759b743528000010', order: '1', title: "Part 1", slug: "part_1")
+    edition.parts.build(_id: '54c10d4d759b743528000011', order: '3', title: "Part 3", slug: "part_3")
+    edition.parts.build(_id: '54c10d4d759b743528000012', order: '2', title: "Part 2", slug: "part_2")
+    assert_equal("# Part 1\n\n\n\n# Part 2\n\n\n\n# Part 3\n\n", edition.whole_body)
+  end
 end


### PR DESCRIPTION
Mongoid no longer automatically orders embedded or related items, so items can appear out of order. This affected the diff tab in Publisher, where editors were seeing the parts out of order and also editions not being compared against the correct previous version.

Zendesk tickets:
https://govuk.zendesk.com/agent/tickets/1286068
https://govuk.zendesk.com/agent/tickets/1283123
