### PR TITLE
Bump version to 34.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 34.0.0
+
+- Removes `legacy_source` tag [#368](https://github.com/alphagov/govuk_content_models/pull/368)
+
 ## 33.0.0
 
 - Changes `save_as_task` to `save_as_task!` [#364](https://github.com/alphagov/govuk_content_models/pull/364)

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "33.0.0"
+  VERSION = "34.0.0"
 end


### PR DESCRIPTION
Part of: https://trello.com/c/ODNdKlkp/564-remove-legacy-source-from-panopticon