### PR TITLE
Merge master back into rails-mongoid-upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 33.0.0
+
+- Changes `save_as_task` to `save_as_task!` [#364](https://github.com/alphagov/govuk_content_models/pull/364)
+
 ## 32.3.1
 
 - Update the Artefact FactoryGirl definition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 34.0.0
+
+- Removes `legacy_source` tag [#368](https://github.com/alphagov/govuk_content_models/pull/368)
+
 ## 33.0.0
 
 - Changes `save_as_task` to `save_as_task!` [#364](https://github.com/alphagov/govuk_content_models/pull/364)

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -321,12 +321,12 @@ class Artefact
   # We should use this method when performing save actions from rake tasks,
   # message queue consumer or any other performed tasks that have no user associated
   # as we are still interested to know what triggered the action.
-  def save_as_task(task_name, options = {})
+  def save_as_task!(task_name, options = {})
     default_action = new_record? ? "create" : "update"
     action_type = options.delete(:action_type) || default_action
 
     record_action(action_type, task_name: task_name)
-    save(options)
+    save!(options)
   end
 
   def record_create_action

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -17,7 +17,7 @@ class Artefact
 
   include Taggable
   stores_tags_for :sections, :writing_teams, :propositions,
-                  :keywords, :legacy_sources, :specialist_sectors, :organisations
+                  :keywords, :specialist_sectors, :organisations
   has_primary_tag_for :section
 
   field "name",                 type: String

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "32.3.1"
+  VERSION = "33.0.0"
 end

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "33.0.0"
+  VERSION = "34.0.0"
 end

--- a/test/models/artefact_action_test.rb
+++ b/test/models/artefact_action_test.rb
@@ -93,7 +93,7 @@ class ArtefactActionTest < ActiveSupport::TestCase
 
   test "saving a task should record the task action" do
     @artefact.description = "Updated automatically"
-    @artefact.save_as_task('TaggingUpdater')
+    @artefact.save_as_task!('TaggingUpdater')
     @artefact.reload
 
     assert_equal 2, @artefact.actions.size

--- a/test/models/artefact_tag_test.rb
+++ b/test/models/artefact_tag_test.rb
@@ -3,9 +3,6 @@ require "test_helper"
 class ArtefactTagTest < ActiveSupport::TestCase
 
   TEST_KEYWORDS = [['cheese', 'Cheese'], ['bacon', 'Bacon']]
-  TEST_LEGACY_SOURCES = [
-    ['businesslink', 'Business Link'], ['directgov', 'Directgov'], ['dvla', 'DVLA']
-  ]
 
   setup do
     parent_section = FactoryGirl.create(:live_tag, :tag_id => 'crime', :tag_type => 'section', :title => 'Crime')
@@ -14,9 +11,6 @@ class ArtefactTagTest < ActiveSupport::TestCase
 
     TEST_KEYWORDS.each do |tag_id, title|
       FactoryGirl.create(:live_tag, :tag_id => tag_id, :tag_type => 'keyword', :title => title)
-    end
-    TEST_LEGACY_SOURCES.each do |tag_id, title|
-      FactoryGirl.create(:live_tag, :tag_id => tag_id, :tag_type => 'legacy_source', :title => title)
     end
   end
 
@@ -43,25 +37,14 @@ class ArtefactTagTest < ActiveSupport::TestCase
     a = FactoryGirl.create(:artefact)
 
     a.sections = ['crime', 'crime/the-police']
-    a.legacy_sources = ['businesslink']
     a.keywords = ['bacon']
 
     expected_tags = [
       { "tag_id" => "crime", "tag_type" => "section" },
       { "tag_id" => "crime/the-police", "tag_type" => "section" },
-      { "tag_id" => "businesslink", "tag_type" => "legacy_source" },
       { "tag_id" => "bacon", "tag_type" => "keyword" },
     ]
-    assert_equal ["crime", "crime/the-police", "businesslink", "bacon"], a.tag_ids
+    assert_equal ["crime", "crime/the-police", "bacon"], a.tag_ids
     assert_equal expected_tags, a.attributes["tags"]
-  end
-
-  test "has legacy_sources tag collection" do
-    a = FactoryGirl.build(:artefact)
-    a.legacy_sources = ['businesslink', 'dvla']
-    a.save
-
-    a = Artefact.first
-    assert_equal ["businesslink", "dvla"], a.legacy_source_ids
   end
 end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -551,9 +551,6 @@ class ArtefactTest < ActiveSupport::TestCase
       setup do
         FactoryGirl.create(:live_tag, :tag_type => 'section', :tag_id => 'crime', :title => 'Crime')
         FactoryGirl.create(:live_tag, :tag_type => 'section', :tag_id => 'justice', :title => 'Justice', :description => "All about justice")
-        FactoryGirl.create(:live_tag, :tag_type => 'legacy_source', :tag_id => 'directgov', :title => 'Directgov')
-        FactoryGirl.create(:live_tag, :tag_type => 'legacy_source', :tag_id => 'businesslink', :title => 'Business Link')
-
         @a = FactoryGirl.create(:artefact, :slug => 'fooey')
       end
 
@@ -567,14 +564,13 @@ class ArtefactTest < ActiveSupport::TestCase
       context "for an artefact with tags" do
         setup do
           @a.sections = ['justice']
-          @a.legacy_sources = ['businesslink']
           @a.save!
         end
 
         should "return an array of tag_id strings in tag_ids" do
           hash = @a.as_json
 
-          assert_equal ['justice', 'businesslink'], hash['tag_ids']
+          assert_equal ['justice'], hash['tag_ids']
         end
 
         should "return an array of tag objects in tags" do
@@ -588,13 +584,6 @@ class ArtefactTest < ActiveSupport::TestCase
               :description => 'All about justice',
               :short_description => nil
             },
-            {
-              :id => 'businesslink',
-              :title => 'Business Link',
-              :type => 'legacy_source',
-              :description => nil,
-              :short_description => nil
-            }
           ]
           assert_equal expected, hash['tags']
         end
@@ -603,7 +592,7 @@ class ArtefactTest < ActiveSupport::TestCase
           @a.tag_ids << 'batman'
           hash = @a.as_json
 
-          assert_equal %w(justice businesslink), hash['tags'].map {|t| t[:id] }
+          assert_equal %w(justice), hash['tags'].map {|t| t[:id] }
         end
       end
     end


### PR DESCRIPTION
The rails-mongoid-upgrade branch is used by publisher since alphagov/publisher#454 to provide support for Mongoid 5. Since this branch was last updated there have been updates to this repo.

This PR merges everything from master back into this branch.

Same story as https://github.com/alphagov/govuk_content_models/pull/366

cc @danielroseman 