### PR TITLE
Add the register to vote done page promotion toggles

### DIFF
--- a/lib/govuk_content_models/presentation_toggles.rb
+++ b/lib/govuk_content_models/presentation_toggles.rb
@@ -25,14 +25,38 @@ module PresentationToggles
   end
 
   def organ_donor_registration_key
-    presentation_toggles['organ_donor_registration']
+    presentation_toggles['organ_donor_registration'] || self.class.default_presentation_toggles['organ_donor_registration']
+  end
+
+  def promote_register_to_vote=(value)
+    value = value.is_a?(Boolean) ? value : value != '0' # if assigned using a checkbox
+    register_to_vote_key['promote_register_to_vote'] = value
+  end
+
+  def promote_register_to_vote
+    register_to_vote_key['promote_register_to_vote']
+  end
+  alias_method :promote_register_to_vote?, :promote_register_to_vote
+
+  def register_to_vote_url=(value)
+    register_to_vote_key['register_to_vote_url'] = value
+  end
+  
+  def register_to_vote_url
+    register_to_vote_key['register_to_vote_url']
+  end
+
+  def register_to_vote_key
+    presentation_toggles['register_to_vote'] || self.class.default_presentation_toggles['register_to_vote']
   end
 
   module ClassMethods
     def default_presentation_toggles
       {
         'organ_donor_registration' =>
-          { 'promote_organ_donor_registration' => false, 'organ_donor_registration_url' => '' }
+          { 'promote_organ_donor_registration' => false, 'organ_donor_registration_url' => '' },
+        'register_to_vote' =>
+          { 'promote_register_to_vote' => false, 'register_to_vote_url' => '' },
       }
     end
   end


### PR DESCRIPTION
- We're adding a new promotion to transaction done pages to encourage
  people to register to vote. This requires some methods adding here so
  that it all works across publisher and frontend.

(Related branches: https://github.com/alphagov/publisher/tree/add_register_to_vote_promo_checkbox and https://github.com/alphagov/frontend/compare/add_register_to_vote_done_page_promotion. Trello card: https://trello.com/c/dXgKpUBZ/340-register-to-vote-promotion-on-done-pages-3.)

(Once this is here, we'll need to merge master back into the `rails-mongoid-upgrade` branch so that Publisher can use it, because of https://github.com/alphagov/publisher/blob/6ecc4b8300284c9bdf1ce6e1d5bf9a421286e526/Gemfile#L14. Tested this in dev by cherry-picking this commit onto the `rails-mongoid-upgrade` branch temporarily and it did what we wanted.)