### PR TITLE
Refactor presentation toggles to nicely support new done page promos

### DIFF
--- a/lib/govuk_content_models/presentation_toggles.rb
+++ b/lib/govuk_content_models/presentation_toggles.rb
@@ -4,6 +4,8 @@ module PresentationToggles
   included do
     field :presentation_toggles, type: Hash, default: default_presentation_toggles
     validates_presence_of :organ_donor_registration_url, if: :promote_organ_donor_registration?
+    validates :promotion_choice_url, presence: true, if: :promotes_something?
+    validates :promotion_choice, inclusion: { in: %w(none organ_donor register_to_vote) }
   end
 
   def promote_organ_donor_registration=(value)
@@ -19,7 +21,7 @@ module PresentationToggles
   def organ_donor_registration_url=(value)
     organ_donor_registration_key['organ_donor_registration_url'] = value
   end
-  
+
   def organ_donor_registration_url
     organ_donor_registration_key['organ_donor_registration_url']
   end
@@ -29,17 +31,13 @@ module PresentationToggles
   end
 
   def promotion_choice=(value)
-    is_valid = ["none", "organ_donor", "register_to_vote"].include?(value)
-    if is_valid
-      promotion_choice_key["choice"] = value
-    end
-    # XXX: Should we throw if value is not valid?
+    promotion_choice_key["choice"] = value
   end
 
   def promotion_choice_url=(value)
     promotion_choice_key['url'] = value
   end
-  
+
   def promotion_choice
     has_legacy_promote = promote_organ_donor_registration
     choice = promotion_choice_key["choice"]
@@ -53,7 +51,10 @@ module PresentationToggles
       choice
     end
   end
-  alias_method :promotion_choice?, :promotion_choice
+
+  def promotes_something?
+    promotion_choice != 'none'
+  end
 
   def promotion_choice_url
     url = promotion_choice_key["url"]

--- a/lib/govuk_content_models/presentation_toggles.rb
+++ b/lib/govuk_content_models/presentation_toggles.rb
@@ -28,35 +28,55 @@ module PresentationToggles
     presentation_toggles['organ_donor_registration'] || self.class.default_presentation_toggles['organ_donor_registration']
   end
 
-  def promote_register_to_vote=(value)
-    value = value.is_a?(Boolean) ? value : value != '0' # if assigned using a checkbox
-    register_to_vote_key['promote_register_to_vote'] = value
+  def promotion_choice=(value)
+    is_valid = ["none", "organ_donor", "register_to_vote"].include?(value)
+    if is_valid
+      promotion_choice_key["choice"] = value
+    end
+    # XXX: Should we throw if value is not valid?
   end
 
-  def promote_register_to_vote
-    register_to_vote_key['promote_register_to_vote']
-  end
-  alias_method :promote_register_to_vote?, :promote_register_to_vote
-
-  def register_to_vote_url=(value)
-    register_to_vote_key['register_to_vote_url'] = value
+  def promotion_choice_url=(value)
+    promotion_choice_key['url'] = value
   end
   
-  def register_to_vote_url
-    register_to_vote_key['register_to_vote_url']
+  def promotion_choice
+    has_legacy_promote = promote_organ_donor_registration
+    choice = promotion_choice_key["choice"]
+    if choice.empty?
+      if has_legacy_promote
+        "organ_donor"
+      else
+        "none"
+      end
+    else
+      choice
+    end
+  end
+  alias_method :promotion_choice?, :promotion_choice
+
+  def promotion_choice_url
+    url = promotion_choice_key["url"]
+    url.empty? ? organ_donor_registration_url : url
   end
 
-  def register_to_vote_key
-    presentation_toggles['register_to_vote'] || self.class.default_presentation_toggles['register_to_vote']
+  def promotion_choice_key
+    presentation_toggles['promotion_choice'] || self.class.default_presentation_toggles['promotion_choice']
   end
 
   module ClassMethods
     def default_presentation_toggles
       {
         'organ_donor_registration' =>
-          { 'promote_organ_donor_registration' => false, 'organ_donor_registration_url' => '' },
-        'register_to_vote' =>
-          { 'promote_register_to_vote' => false, 'register_to_vote_url' => '' },
+          {
+            'promote_organ_donor_registration' => false,
+            'organ_donor_registration_url' => ''
+          },
+        'promotion_choice' =>
+          {
+            'choice' => '',
+            'url' => ''
+          }
       }
     end
   end

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -34,6 +34,21 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
     assert_includes completed_transaction_edition.errors[:organ_donor_registration_url], "can't be blank"
   end
 
+  test "invalid if promotion_choice_url is not specified when a promotion choice is made" do
+    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition,
+      promotion_choice: 'organ_donor', promotion_choice_url: "")
+
+    assert completed_transaction_edition.invalid?
+    assert_includes completed_transaction_edition.errors[:promotion_choice_url], "can't be blank"
+  end
+
+  test "invalid if promotion_choice is not one of the allowed ones" do
+    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition, promotion_choice: 'cheese')
+
+    assert completed_transaction_edition.invalid?
+    assert_includes completed_transaction_edition.errors[:promotion_choice], "is not included in the list"
+  end
+
   test "stores promotion choice and URL" do
     completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition)
 

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -33,4 +33,38 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
     assert completed_transaction_edition.invalid?
     assert_includes completed_transaction_edition.errors[:organ_donor_registration_url], "can't be blank"
   end
+
+  test "stores promotion choice and URL" do
+    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition)
+
+    completed_transaction_edition.promotion_choice = "none"
+    completed_transaction_edition.save!
+
+    assert_equal "none", completed_transaction_edition.reload.promotion_choice
+
+    completed_transaction_edition.promotion_choice = "organ_donor"
+    completed_transaction_edition.promotion_choice_url = "https://www.organdonation.nhs.uk/registration/"
+    completed_transaction_edition.save!
+
+    assert_equal "organ_donor", completed_transaction_edition.reload.promotion_choice
+    assert_equal "https://www.organdonation.nhs.uk/registration/", completed_transaction_edition.promotion_choice_url
+
+    completed_transaction_edition.promotion_choice = "register_to_vote"
+    completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/register-to-vote"
+    completed_transaction_edition.save!
+
+    assert_equal "register_to_vote", completed_transaction_edition.reload.promotion_choice
+    assert_equal "https://www.gov.uk/register-to-vote", completed_transaction_edition.promotion_choice_url
+  end
+
+  test "passes through legacy organ donor info" do
+    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition,
+      promote_organ_donor_registration: true)
+
+    completed_transaction_edition.organ_donor_registration_url = "https://www.organdonation.nhs.uk/registration/"
+    completed_transaction_edition.save!
+
+    assert_equal "organ_donor", completed_transaction_edition.reload.promotion_choice
+    assert_equal "https://www.organdonation.nhs.uk/registration/", completed_transaction_edition.promotion_choice_url
+  end
 end


### PR DESCRIPTION
- Refactored f852133887b7dc455fdcf62719b440d446554bc2 as in doing the
  Publisher parts of this, we realised we needed to use radio buttons
  for mutually exclusive options (either "register to vote" or "organ
  donation"), and the current presentation toggles model didn't do what
  Rails radio buttons (or radio buttons in general) wanted: the same
  IDs.
- This adds a new `promotion_choice` method, with its associated keys,
  with `none` being its default "choice" and an empty string being its
  default "url" method, so that the current behaviour of not having to
  select a promotion continues to exist.
- This continues to support legacy `promote_organ_donation` code,
  because of the existing done pages (20-odd) that have it, but
  transitions them to the new way of doing things if they have those
  attributes set, so that eventually we can remove the old, organ
  donor-specific code in favour of "any promo you want as long as it's
  in the allowed list of `promotion_choice`s".

Thanks very much to @tvararu for pairing on the Publisher checkboxes/radio button part of this, during which we uncovered this rabbit hole and fixed it! Should anyone (team) require any context while I'm away, he has it, and I'll write some notes on the Trello card. ⭐ 