### PR TITLE
Add request_id field to TravelAdviceEdition...

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -22,6 +22,7 @@ class TravelAdviceEdition
   # This is the publicly presented publish time. For minor updates, this will be the publish time of the previous version
   field :published_at,         type: Time
   field :reviewed_at,          type: Time
+  field :request_id,           type: String
 
   embeds_many :actions
 

--- a/test/models/travel_advice_edition_test.rb
+++ b/test/models/travel_advice_edition_test.rb
@@ -19,6 +19,7 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
     ed.change_description = "Some things"
     ed.synonyms = ["Foo", "Bar"]
     ed.parts.build(:title => "Part One", :slug => "one")
+    ed.request_id = "2546-1460985144476-19268198-3242"
     ed.safely.save!
 
     ed = TravelAdviceEdition.first
@@ -35,6 +36,7 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
     assert_equal ["Foo", "Bar"], ed.synonyms
     assert_equal "Some things", ed.change_description
     assert_equal "Part One", ed.parts.first.title
+    assert_equal "2546-1460985144476-19268198-3242", ed.request_id
   end
 
   context "validations" do


### PR DESCRIPTION
https://trello.com/c/Io2JYTFv/27-ensure-request-id-is-available-to-multipage-frontend-and-frontend-apps

In order to trace requests thoroughly, we need to persist the request_id
from publishing applications so this can be present in rendered content
once published. This helps to tie a content update as it passes through
the publishing pipeline.