### PR TITLE
Update rails development dependency to 3.2.22

### DIFF
--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |gem|
 
   # The following are added to help bundler resolve dependencies
   gem.add_development_dependency "rack", "~> 1.4.4"
-  gem.add_development_dependency "rails", "= 3.2.17"
+  gem.add_development_dependency "rails", "~> 3.2.22"
 end


### PR DESCRIPTION
We receive notifications when our projects have gems with security vulnerabilities.

Even though this dependency is only used under development, I've updated the version to silence the notification.

```
$ govuk_security_audit check govuk_content_models/
Updating ruby-advisory-db ...
remote: Counting objects: 6, done.
remote: Total 6 (delta 2), reused 2 (delta 2), pack-reused 4
Unpacking objects: 100% (6/6), done.
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
   b08435d..c1f265c  master     -> origin/master
Updating b08435d..c1f265c
Fast-forward
 gems/spina/CVE-2015-4619.yml | 16 ++++++++++++++++
 1 file changed, 16 insertions(+)
 create mode 100644 gems/spina/CVE-2015-4619.yml
ruby-advisory-db: 266 advisories
Name: actionpack
Version: 3.2.17
Advisory: CVE-2014-7829
Criticality: Medium
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/rMTQy4oRCGk
Title: Arbitrary file existence disclosure in Action Pack
Solution: upgrade to ~> 3.2.21, ~> 4.0.11.1, ~> 4.0.12, ~> 4.1.7.1, >= 4.1.8

Name: actionpack
Version: 3.2.17
Advisory: CVE-2014-0130
Criticality: Medium
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/NkKc7vTW70o
Title: Directory Traversal Vulnerability With Certain Route Configurations
Solution: upgrade to ~> 3.2.18, ~> 4.0.5, >= 4.1.1

Name: actionpack
Version: 3.2.17
Advisory: CVE-2016-0751
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/9oLY_FCzvoc
Title: Possible Object Leak and Denial of Service attack in Action Pack
Solution: upgrade to ~> 5.0.0.beta1.1, >= 4.2.5.1, ~> 4.2.5, >= 4.1.14.1, ~> 4.1.14, ~> 3.2.22.1

Name: actionpack
Version: 3.2.17
Advisory: CVE-2016-2098
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/ly-IH-fxr_Q
Title: Possible remote code execution vulnerability in Action Pack
Solution: upgrade to ~> 3.2.22.2, >= 4.2.5.2, ~> 4.2.5, >= 4.1.14.2, ~> 4.1.14

Name: actionpack
Version: 3.2.17
Advisory: CVE-2014-7818
Criticality: Medium
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/dCp7duBiQgo
Title: Arbitrary file existence disclosure in Action Pack
Solution: upgrade to ~> 3.2.20, ~> 4.0.11, ~> 4.1.7, >= 4.2.0.beta3

Name: actionpack
Version: 3.2.17
Advisory: CVE-2015-7576
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/ANv0HDHEC3k
Title: Timing attack vulnerability in basic authentication in Action Controller.
Solution: upgrade to ~> 5.0.0.beta1.1, >= 4.2.5.1, ~> 4.2.5, >= 4.1.14.1, ~> 4.1.14, ~> 3.2.22.1

Name: activerecord
Version: 3.2.17
Advisory: CVE-2014-3482
Criticality: Unknown
URL: http://osvdb.org/show/osvdb/108664
Title: SQL Injection Vulnerability in Active Record
Solution: upgrade to ~> 3.2.19

Name: activerecord
Version: 3.2.17
Advisory: CVE-2015-7577
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/cawsWcQ6c8g
Title: Nested attributes rejection proc bypass in Active Record
Solution: upgrade to ~> 5.0.0.beta1.1, >= 4.2.5.1, ~> 4.2.5, >= 4.1.14.1, ~> 4.1.14, ~> 3.2.22.1

Name: activesupport
Version: 3.2.17
Advisory: CVE-2015-3227
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/bahr2JLnxvk
Title: Possible Denial of Service attack in Active Support
Solution: upgrade to >= 4.2.2, ~> 4.1.11, ~> 3.2.22

Name: mail
Version: 2.5.4
Advisory: 131677
Criticality: Unknown
URL: http://www.mbsd.jp/Whitepaper/smtpi.pdf
Title: Mail Gem for Ruby vulnerable to SMTP Injection via recipient email addresses
Solution: upgrade to >= 2.6.0
```