### PR TITLE
Implement "fall back" for legacy promotions correctly

### DIFF
--- a/lib/govuk_content_models/presentation_toggles.rb
+++ b/lib/govuk_content_models/presentation_toggles.rb
@@ -27,7 +27,7 @@ module PresentationToggles
   end
 
   def organ_donor_registration_key
-    presentation_toggles['organ_donor_registration'] || self.class.default_presentation_toggles['organ_donor_registration']
+    presentation_toggles['organ_donor_registration'] ||= self.class.default_presentation_toggles['organ_donor_registration']
   end
 
   def promotion_choice=(value)
@@ -62,7 +62,7 @@ module PresentationToggles
   end
 
   def promotion_choice_key
-    presentation_toggles['promotion_choice'] || self.class.default_presentation_toggles['promotion_choice']
+    presentation_toggles['promotion_choice'] ||= self.class.default_presentation_toggles['promotion_choice']
   end
 
   module ClassMethods

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -72,6 +72,36 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
     assert_equal "https://www.gov.uk/register-to-vote", completed_transaction_edition.promotion_choice_url
   end
 
+  test "stores promotion choice and URL on legacy documents" do
+    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition,
+      presentation_toggles: {
+        'organ_donor_registration' => {
+          'promote_organ_donor_registration' => false,
+          'organ_donor_registration_url' => ''
+        },
+      }
+    )
+
+    completed_transaction_edition.promotion_choice = "none"
+    completed_transaction_edition.save!
+
+    assert_equal "none", completed_transaction_edition.reload.promotion_choice
+
+    completed_transaction_edition.promotion_choice = "organ_donor"
+    completed_transaction_edition.promotion_choice_url = "https://www.organdonation.nhs.uk/registration/"
+    completed_transaction_edition.save!
+
+    assert_equal "organ_donor", completed_transaction_edition.reload.promotion_choice
+    assert_equal "https://www.organdonation.nhs.uk/registration/", completed_transaction_edition.promotion_choice_url
+
+    completed_transaction_edition.promotion_choice = "register_to_vote"
+    completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/register-to-vote"
+    completed_transaction_edition.save!
+
+    assert_equal "register_to_vote", completed_transaction_edition.reload.promotion_choice
+    assert_equal "https://www.gov.uk/register-to-vote", completed_transaction_edition.promotion_choice_url
+  end
+
   test "passes through legacy organ donor info" do
     completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition,
       promote_organ_donor_registration: true)


### PR DESCRIPTION
When checking for the "promotion_choice" key inside the
presentation_toggles hash field if it wasn't present we would return the
default hash.  However this wouldn't be stored in the model so any changes
that were written to it would not be persisted.  To fix we write the
default hash into the presentation_toggles if the key wasn't already there.

This fix makes the changes in #374 and #372 actually work when persisting data.  No tests failed because we had none that simulated the real world scenario of a document with only the legacy promo storage scheme.  I've added one.