### PR TITLE
Handle legacy scheme for promos more robustly

### DIFF
--- a/lib/govuk_content_models/presentation_toggles.rb
+++ b/lib/govuk_content_models/presentation_toggles.rb
@@ -27,7 +27,10 @@ module PresentationToggles
   end
 
   def organ_donor_registration_key
-    presentation_toggles['organ_donor_registration'] ||= self.class.default_presentation_toggles['organ_donor_registration']
+    unless presentation_toggles.key? 'organ_donor_registration'
+      presentation_toggles['organ_donor_registration'] = self.class.default_presentation_toggles['organ_donor_registration']
+    end
+    presentation_toggles['organ_donor_registration']
   end
 
   def promotion_choice=(value)
@@ -62,7 +65,10 @@ module PresentationToggles
   end
 
   def promotion_choice_key
-    presentation_toggles['promotion_choice'] ||= self.class.default_presentation_toggles['promotion_choice']
+    unless presentation_toggles.key? 'promotion_choice'
+      presentation_toggles['promotion_choice'] = self.class.default_presentation_toggles['promotion_choice']
+    end
+    presentation_toggles['promotion_choice']
   end
 
   module ClassMethods

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -81,6 +81,15 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
         },
       }
     )
+    completed_transaction_edition.save(validate: false)
+    completed_transaction_edition.reload
+
+    completed_transaction_edition.promotion_choice = "register_to_vote"
+    completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/register-to-vote"
+    completed_transaction_edition.save!
+
+    assert_equal "register_to_vote", completed_transaction_edition.reload.promotion_choice
+    assert_equal "https://www.gov.uk/register-to-vote", completed_transaction_edition.promotion_choice_url
 
     completed_transaction_edition.promotion_choice = "none"
     completed_transaction_edition.save!
@@ -93,13 +102,6 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
 
     assert_equal "organ_donor", completed_transaction_edition.reload.promotion_choice
     assert_equal "https://www.organdonation.nhs.uk/registration/", completed_transaction_edition.promotion_choice_url
-
-    completed_transaction_edition.promotion_choice = "register_to_vote"
-    completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/register-to-vote"
-    completed_transaction_edition.save!
-
-    assert_equal "register_to_vote", completed_transaction_edition.reload.promotion_choice
-    assert_equal "https://www.gov.uk/register-to-vote", completed_transaction_edition.promotion_choice_url
   end
 
   test "passes through legacy organ donor info" do


### PR DESCRIPTION
In 46f2e931cf8373efa59a9e187f0c7b18e7b1f6d8 we changed how we handled
missing "promotion_choice" keys in the presentation_toggles field to
better deal with existing documents that didn't have that key because
they were created before the new defaults were in place.  Our solution
used ``||=`` to store the default values in the presentation_toggles
hash for the key if it wasn't already present.

Our test for this worked with an unsaved object which meant that the
presentation_toggles field was still an instance of Hash.  Once it's
saved to the DB however and retrieved it becomes a BSON::Document and
this has slightly different semantics for ``||=`` assignment.

With a hash:

    a = {}
    b = {foo: {bar: "baz"}}
    c = (a[:foo] ||= b[:foo])
    c.object_id == a[:foo].object_id

Then the final line returns `true`.  However if `a` in this example
is a BSON::Document and not a Hash then the final line returns `false`.
This means that anything we do to `c` isn't actually acting on the
data stored in `a[:foo]`, but on the value we get from `b[:foo]`.

Having worked this out we change the test to work on a saved instance
to trigger the failure.  Note that to properly construct an instance
without `promotion_choice` in presentation_toggles we need to save
without validations as one of our validations would end up populating
the `promotion_choice` key and this would mean our test wouldn't be
a true example of real world data.

The solution is then to unroll the ``||=`` and do the assignment and
return in two steps, ensuring that we only expose the data stored in
presentation_toggles rather than the data we wanted to put in.