### PR TITLE
	Define start button text for SimpleSmartAnswerEdition 

### DIFF
--- a/app/models/simple_smart_answer_edition.rb
+++ b/app/models/simple_smart_answer_edition.rb
@@ -5,7 +5,10 @@ require_relative 'simple_smart_answer_edition/node/option'
 class SimpleSmartAnswerEdition < Edition
   include Mongoid::Document
 
-  field :body, type: String
+  field :body,              type: String
+  field :start_button_text, type: String, default: "Start now"
+
+  validates_presence_of :start_button_text
 
   embeds_many :nodes, :class_name => "SimpleSmartAnswerEdition::Node"
 
@@ -34,11 +37,11 @@ class SimpleSmartAnswerEdition < Edition
 
   # Workaround mongoid conflicting mods error
   # See https://jira.mongodb.org/browse/MONGOID-1220
-  # Override update_attributes so that nested nodes are updated individually. 
-  # This get around the problem of mongoid issuing a query with conflicting modifications 
-  # to the same document. 
+  # Override update_attributes so that nested nodes are updated individually.
+  # This get around the problem of mongoid issuing a query with conflicting modifications
+  # to the same document.
   alias_method :original_update_attributes, :update_attributes
-  
+
   def update_attributes(attributes)
     if nodes_attrs = attributes.delete(:nodes_attributes)
       nodes_attrs.each do |index, node_attrs|

--- a/test/models/simple_smart_answer_edition_test.rb
+++ b/test/models/simple_smart_answer_edition_test.rb
@@ -100,6 +100,48 @@ class SimpleSmartAnswerEditionTest < ActiveSupport::TestCase
     assert_equal 1, edition.nodes.size
   end
 
+  context "SimpleSmartAnswerEdition: Start Button" do
+    setup do
+      @edition_attributes = {
+        panopticon_id: @artefact.id,
+        body: "This is a simple smart answer with a default text for start button."
+      }
+    end
+    context "with default text" do
+      setup do
+        edition = FactoryGirl.build(:simple_smart_answer_edition, @edition_attributes)
+        edition.save!
+      end
+
+      should "be created with the default text for start button" do
+        edition = SimpleSmartAnswerEdition.first
+
+        assert_equal "Start now", edition.start_button_text
+        assert_equal "This is a simple smart answer with a default text for start button.", edition.body
+        assert_equal @artefact.id.to_s, edition.panopticon_id
+      end
+    end
+
+    context "when button text changes" do
+      setup do
+        edition = FactoryGirl.build(
+          :simple_smart_answer_edition,
+          @edition_attributes.merge(start_button_text: "Click to start")
+        )
+        edition.save!
+      end
+
+      should "be created with the text given by the content creator" do
+        edition = SimpleSmartAnswerEdition.first
+
+        refute_equal "Start Now", edition.start_button_text
+        assert_equal "Click to start", edition.start_button_text
+        assert_equal "This is a simple smart answer with a default text for start button.", edition.body
+        assert_equal @artefact.id.to_s, edition.panopticon_id
+      end
+    end
+  end
+
   context "update_attributes method" do
     setup do
       @edition = FactoryGirl.create(:simple_smart_answer_edition)


### PR DESCRIPTION
As requested in this [Trello card](https://trello.com/c/CUe4odRB/45-make-start-now-editable-in-simple-smart-answers), the need to add the capability to change the text of the start button for simple smart answers.

Here, I have defined a new attribute "start_button_text" default text of "Start now", followed with tests 

Related PRs
* [Publisher](https://github.com/alphagov/publisher/pull/474)
* [Content API](https://github.com/alphagov/govuk_content_api/pull/242)
* [Frontend](https://github.com/alphagov/frontend/pull/950)

SEE Trello ticket

![screen shot 2016-05-03 at 16 41 13](https://cloud.githubusercontent.com/assets/84896/14989058/f3de416e-114d-11e6-81c3-4608510997df.png)