### PR TITLE
Add conditionals to questions in simple smart answers

### DIFF
--- a/app/models/simple_smart_answer_edition/node/option.rb
+++ b/app/models/simple_smart_answer_edition/node/option.rb
@@ -6,6 +6,7 @@ class SimpleSmartAnswerEdition < Edition
       include Mongoid::Document
 
       embedded_in :node, :class_name => "SimpleSmartAnswerEdition::Node"
+      embeds_many :conditions, :class_name => "SimpleSmartAnswerEdition::Node::Option::Condition"
 
       field :label, type: String
       field :slug, type: String

--- a/app/models/simple_smart_answer_edition/node/option.rb
+++ b/app/models/simple_smart_answer_edition/node/option.rb
@@ -8,6 +8,8 @@ class SimpleSmartAnswerEdition < Edition
       embedded_in :node, :class_name => "SimpleSmartAnswerEdition::Node"
       embeds_many :conditions, :class_name => "SimpleSmartAnswerEdition::Node::Option::Condition"
 
+      accepts_nested_attributes_for :conditions, :allow_destroy => true
+
       field :label, type: String
       field :slug, type: String
       field :next_node, type: String
@@ -15,8 +17,9 @@ class SimpleSmartAnswerEdition < Edition
 
       default_scope lambda { order_by(order: :asc) }
 
-      validates :label, :next_node, presence: true
+      validates :label, presence: true
       validates :slug, :format => {:with => /\A[a-z0-9-]+\z/}
+      validate :either_next_node_or_conditions
 
       before_validation :populate_slug
 
@@ -25,6 +28,14 @@ class SimpleSmartAnswerEdition < Edition
       def populate_slug
         if label.present? && !slug_changed?
           self.slug = ActiveSupport::Inflector.parameterize(label)
+        end
+      end
+
+      def either_next_node_or_conditions
+        if next_node
+          errors.add(:conditions, "cannot be added when the next node is defined") if conditions.present? and conditions.any?
+        else
+          errors.add(:next_node, "must be populated when there are no conditions defined") unless conditions.present? and conditions.any?
         end
       end
     end

--- a/app/models/simple_smart_answer_edition/node/option.rb
+++ b/app/models/simple_smart_answer_edition/node/option.rb
@@ -6,9 +6,9 @@ class SimpleSmartAnswerEdition < Edition
       include Mongoid::Document
 
       embedded_in :node, :class_name => "SimpleSmartAnswerEdition::Node"
-      embeds_many :conditions, :class_name => "SimpleSmartAnswerEdition::Node::Option::Condition"
+      embeds_many :conditions, class_name: "SimpleSmartAnswerEdition::Node::Option::Condition"
 
-      accepts_nested_attributes_for :conditions, :allow_destroy => true
+      accepts_nested_attributes_for :conditions, allow_destroy: true
 
       field :label, type: String
       field :slug, type: String
@@ -33,9 +33,9 @@ class SimpleSmartAnswerEdition < Edition
 
       def either_next_node_or_conditions
         if next_node
-          errors.add(:conditions, "cannot be added when the next node is defined") if conditions.present? and conditions.any?
+          errors.add(:conditions, "cannot be added when the next node is defined") if conditions.present? && conditions.any?
         else
-          errors.add(:next_node, "must be populated when there are no conditions defined") unless conditions.present? and conditions.any?
+          errors.add(:next_node, "must be populated when there are no conditions defined") unless conditions.present? && conditions.any?
         end
       end
     end

--- a/app/models/simple_smart_answer_edition/node/option.rb
+++ b/app/models/simple_smart_answer_edition/node/option.rb
@@ -32,7 +32,7 @@ class SimpleSmartAnswerEdition < Edition
       end
 
       def either_next_node_or_conditions
-        if next_node
+        if next_node.present?
           errors.add(:conditions, "cannot be added when the next node is defined") if conditions.present? && conditions.any?
         else
           errors.add(:next_node, "must be populated when there are no conditions defined") unless conditions.present? && conditions.any?

--- a/app/models/simple_smart_answer_edition/node/option/condition.rb
+++ b/app/models/simple_smart_answer_edition/node/option/condition.rb
@@ -9,6 +9,9 @@ class SimpleSmartAnswerEdition < Edition
         field :slug, type: String
         field :label, type: String
         field :next_node, type: String
+        field :order, type: Integer
+
+        default_scope lambda { order_by(order: :asc) }
 
         validates :slug, :label, :next_node, presence: true
         validates :slug, format: { with: /\A[a-z0-9-]+\z/ }

--- a/app/models/simple_smart_answer_edition/node/option/condition.rb
+++ b/app/models/simple_smart_answer_edition/node/option/condition.rb
@@ -4,14 +4,14 @@ class SimpleSmartAnswerEdition < Edition
       class Condition
         include Mongoid::Document
 
-        embedded_in :option, :class_name => "SimpleSmartAnswerEdition::Node::Option"
+        embedded_in :option, class_name: "SimpleSmartAnswerEdition::Node::Option"
 
         field :slug, type: String
         field :label, type: String
         field :next_node, type: String
 
         validates :slug, :label, :next_node, presence: true
-        validates :slug, :format => {:with => /\A[a-z0-9-]+\z/}
+        validates :slug, format: { with: /\A[a-z0-9-]+\z/ }
       end
     end
   end

--- a/app/models/simple_smart_answer_edition/node/option/condition.rb
+++ b/app/models/simple_smart_answer_edition/node/option/condition.rb
@@ -1,0 +1,18 @@
+class SimpleSmartAnswerEdition < Edition
+  class Node
+    class Option
+      class Condition
+        include Mongoid::Document
+
+        embedded_in :option, :class_name => "SimpleSmartAnswerEdition::Node::Option"
+
+        field :slug, type: String
+        field :label, type: String
+        field :next_node, type: String
+
+        validates :slug, :label, :next_node, presence: true
+        validates :slug, :format => {:with => /\A[a-z0-9-]+\z/}
+      end
+    end
+  end
+end

--- a/test/models/simple_smart_answer_condition_test.rb
+++ b/test/models/simple_smart_answer_condition_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class SimpleSmartAnswerConditionTest < ActiveSupport::TestCase
+  context "given a smart answer node exists with a question" do
+    setup do
+      @option = SimpleSmartAnswerEdition::Node::Option.new(
+        label: "Yes",
+        slug: "question-2",
+        next_node: "question-3"
+      )
+      @edition = FactoryGirl.create(:simple_smart_answer_edition, nodes: [
+        SimpleSmartAnswerEdition::Node.new(
+          slug: "question1",
+          title: "Question One?",
+          kind: "question",
+          options: [@option]
+        )
+      ])
+      @atts = {
+        label: "Yes",
+        slug: "question-1",
+        next_node: "question-3"
+      }
+    end
+
+    should "be able to create a valid condition" do
+      @condition = @option.conditions.build(@atts)
+
+      assert @condition.save!
+      @option.reload
+
+      assert_equal "Yes", @option.conditions.first.label
+      assert_equal "question-1", @option.conditions.first.slug
+      assert_equal "question-3", @option.conditions.first.next_node
+    end
+
+    should "not be valid without the slug of the conditional question" do
+      @condition = @option.conditions.build(@atts.merge(slug: nil))
+
+      refute @condition.valid?
+      assert @condition.errors.keys.include?(:slug)
+    end
+
+    should "not be valid if the slug of conditional question is not valid" do
+      [
+        'under_score',
+        'space space',
+        'punct.u&ation',
+      ].each do |slug|
+        @condition = @option.conditions.build(@atts.merge(slug: slug))
+        refute @condition.valid?
+      end
+    end
+
+    should "not be valid without the value of the conditional question" do
+      @condition = @option.conditions.build(@atts.merge(label: nil))
+
+      refute @condition.valid?
+      assert @condition.errors.keys.include?(:label)
+    end
+
+    should "not be valid without a value for the next_node" do
+      @condition = @option.conditions.build(@atts.merge(next_node: nil))
+
+      refute @condition.valid?
+      assert @condition.errors.keys.include?(:next_node)
+    end
+
+    should "expose the option" do
+      @condition = @option.conditions.create(@atts)
+      @condition.reload
+
+      assert_equal @option, @condition.option
+    end
+  end
+end

--- a/test/models/simple_smart_answer_option_test.rb
+++ b/test/models/simple_smart_answer_option_test.rb
@@ -134,7 +134,7 @@ class SimpleSmartAnswerOptionTest < ActiveSupport::TestCase
 
         @option.reload
         assert_equal 2, @option.conditions.count
-        assert_equal ["Yes", "No"], @option.conditions.all.map(&:label)
+        assert_equal %w(Yes No), @option.conditions.all.map(&:label)
         assert_equal ["question-1", "question-2"], @option.conditions.all.map(&:slug)
         assert_equal ["question-3", "question-4"], @option.conditions.all.map(&:next_node)
       end


### PR DESCRIPTION
Trello story: https://trello.com/c/mzoFV27O/44-ability-to-reuse-a-node-in-simple-smart-answers

## Motivation

The current implementation of Simple Smart Answers only allow you to route users depending on how they have answered the current question. It does not take into account the answers to the questions that have come before.

For example.

If users always have to answer Question 2, but you need to direct users to a different outcome in Question 2, based on their answer in Question 1, at the moment you would have to do this:

```
Q1
Yes -> Q2a
No -> Q2b

Q2a
Yes -> Outcome 1
No -> Outcome 3

Q2b
Yes -> Outcome 2
No -> Outcome 4
```

In this scenario Q2a and Q2b are duplicate questions

The aim of this change is to pave the way to allow questions to be defined like this:

```
Q1
Yes -> Q2
No -> Q2

Q2
Yes
    If Q1 = Yes -> Outcome 1
    If Q1 = No -> Outcome 2
No 
    If Q1 = Yes -> Outcome 3
    If Q1 = No  -> Outcome 4
```

## Assumptions

1. A conditional can refer to one previous question and answer.
2. An option can have many conditionals.
3. Removing a condition only removes one condition
4. Removing an option removes all associated conditions

## Changes

Add an optional Condition class to the Option model that allows you define the next_node in the flow based on the answer to a previous question.