### PR TITLE
Remove fields for local authority contact details

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -11,10 +11,6 @@ class LocalAuthority
   field :snac,               type: String
   field :local_directgov_id, type: Integer
   field :tier,               type: String
-  field :contact_address,    type: Array
-  field :contact_url,        type: String
-  field :contact_phone,      type: String
-  field :contact_email,      type: String
   field :homepage_url,       type: String
 
   validates_uniqueness_of :snac

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -216,13 +216,6 @@ FactoryGirl.define do
     tier "county"
   end
 
-  factory :local_authority_with_contact, parent: :local_authority do
-    contact_address ["line one", "line two", "line three"]
-    contact_url "http://www.magic.com/contact"
-    contact_phone "0206778654"
-    contact_email "contact@local.authority.gov.uk"
-  end
-
   factory :local_interaction do
     association :local_authority
     url "http://some.council.gov/do.html"

--- a/lib/govuk_content_models/test_helpers/factories.rb
+++ b/lib/govuk_content_models/test_helpers/factories.rb
@@ -48,7 +48,7 @@ FactoryGirl.define do
     sequence(:slug) { |n| "slug-#{n}" }
     kind            Artefact::FORMATS.first
     owning_app      'publisher'
-    content_id      { SecureRandom.uuid } 
+    content_id      { SecureRandom.uuid }
 
     trait :whitehall do
       sequence(:slug) {|n| "government/slug--#{n}"}

--- a/lib/govuk_content_models/test_helpers/local_services.rb
+++ b/lib/govuk_content_models/test_helpers/local_services.rb
@@ -1,6 +1,6 @@
 module LocalServicesHelper
   def make_authority(tier, options)
-    authority = FactoryGirl.create(:local_authority_with_contact,
+    authority = FactoryGirl.create(:local_authority,
                                    snac: options[:snac], tier: tier)
     add_service_interaction(authority, options[:lgsl]) if options[:lgsl]
     authority

--- a/test/models/local_authority_test.rb
+++ b/test/models/local_authority_test.rb
@@ -13,20 +13,12 @@ describe LocalAuthority do
                   snac: "AA00",
                   local_directgov_id: 1,
                   tier: "county",
-                  contact_address: ["Line one", "line two", "line three"],
-                  contact_url: "http://example.gov/contact",
-                  contact_phone: "0000000000",
-                  contact_email: "contact@example.gov",
                   homepage_url: 'http://example.gov/')
     authority = LocalAuthority.first
     assert_equal "Example", authority.name
     assert_equal "AA00", authority.snac
     assert_equal 1, authority.local_directgov_id
     assert_equal "county", authority.tier
-    assert_equal ["Line one", "line two", "line three"], authority.contact_address
-    assert_equal "http://example.gov/contact", authority.contact_url
-    assert_equal "0000000000", authority.contact_phone
-    assert_equal "contact@example.gov", authority.contact_email
     assert_equal "http://example.gov/", authority.homepage_url
   end
 


### PR DESCRIPTION
This is the last in a series of PRs to remove local authority contact details, and the others should be merged and deployed before this one:

- https://github.com/alphagov/frontend/pull/962
- https://github.com/alphagov/govuk_content_api/pull/245
- https://github.com/alphagov/publisher/pull/477

https://trello.com/c/asuAAsR6/399-delete-code-related-to-local-authority-contact-details