### PR TITLE
Bump to version 36.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 36.0.0
+
+- Remove fields from LocalAuthority
+  - `contact_address`
+  - `contact_url`
+  - `contact_phone`
+  - `contact_email`
+
 ## 35.0.1
 
 - Handle saving changes to promotion toggles correctly for existing documents [#381](https://github.com/alphagov/govuk_content_models/pull/381)

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "35.0.1"
+  VERSION = "36.0.0"
 end


### PR DESCRIPTION
Contact details removed from LocalAuthority as they are no longer used:
https://trello.com/c/asuAAsR6/399-delete-code-related-to-local-authority-contact-details