### PR TITLE
Remove legacy organ donor api code

### DIFF
--- a/lib/govuk_content_models/presentation_toggles.rb
+++ b/lib/govuk_content_models/presentation_toggles.rb
@@ -3,34 +3,8 @@ module PresentationToggles
 
   included do
     field :presentation_toggles, type: Hash, default: default_presentation_toggles
-    validates_presence_of :organ_donor_registration_url, if: :promote_organ_donor_registration?
     validates :promotion_choice_url, presence: true, if: :promotes_something?
     validates :promotion_choice, inclusion: { in: %w(none organ_donor register_to_vote) }
-  end
-
-  def promote_organ_donor_registration=(value)
-    value = value.is_a?(Boolean) ? value : value != '0' # if assigned using a checkbox
-    organ_donor_registration_key['promote_organ_donor_registration'] = value
-  end
-
-  def promote_organ_donor_registration
-    organ_donor_registration_key['promote_organ_donor_registration']
-  end
-  alias_method :promote_organ_donor_registration?, :promote_organ_donor_registration
-
-  def organ_donor_registration_url=(value)
-    organ_donor_registration_key['organ_donor_registration_url'] = value
-  end
-
-  def organ_donor_registration_url
-    organ_donor_registration_key['organ_donor_registration_url']
-  end
-
-  def organ_donor_registration_key
-    unless presentation_toggles.key? 'organ_donor_registration'
-      presentation_toggles['organ_donor_registration'] = self.class.default_presentation_toggles['organ_donor_registration']
-    end
-    presentation_toggles['organ_donor_registration']
   end
 
   def promotion_choice=(value)
@@ -42,17 +16,8 @@ module PresentationToggles
   end
 
   def promotion_choice
-    has_legacy_promote = promote_organ_donor_registration
     choice = promotion_choice_key["choice"]
-    if choice.empty?
-      if has_legacy_promote
-        "organ_donor"
-      else
-        "none"
-      end
-    else
-      choice
-    end
+    choice.empty? ? "none" : choice
   end
 
   def promotes_something?
@@ -60,8 +25,7 @@ module PresentationToggles
   end
 
   def promotion_choice_url
-    url = promotion_choice_key["url"]
-    url.empty? ? organ_donor_registration_url : url
+    promotion_choice_key["url"]
   end
 
   def promotion_choice_key
@@ -74,11 +38,6 @@ module PresentationToggles
   module ClassMethods
     def default_presentation_toggles
       {
-        'organ_donor_registration' =>
-          {
-            'promote_organ_donor_registration' => false,
-            'organ_donor_registration_url' => ''
-          },
         'promotion_choice' =>
           {
             'choice' => '',

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -3,35 +3,17 @@ require "test_helper"
 class CompletedTransactionEditionTest < ActiveSupport::TestCase
   test "controls whether organ donor registration promotion should be displayed on a completed transaction page" do
     completed_transaction_edition = FactoryGirl.create(:completed_transaction_edition)
-    refute completed_transaction_edition.promote_organ_donor_registration?
+    refute completed_transaction_edition.promotes_something?
 
-    completed_transaction_edition.promote_organ_donor_registration = true
-    completed_transaction_edition.organ_donor_registration_url = "https://www.organdonation.nhs.uk/registration/"
+    completed_transaction_edition.promotion_choice = "organ_donor"
+    completed_transaction_edition.promotion_choice_url = "https://www.organdonation.nhs.uk/registration/"
+
     completed_transaction_edition.save!
-    assert completed_transaction_edition.reload.promote_organ_donor_registration?
+    assert completed_transaction_edition.reload.promotes_something?
 
-    completed_transaction_edition.promote_organ_donor_registration = false
+    completed_transaction_edition.promotion_choice = ''
     completed_transaction_edition.save!
-    refute completed_transaction_edition.reload.promote_organ_donor_registration?
-  end
-
-  test "stores organ donor registration promotion URL" do
-    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition,
-      promote_organ_donor_registration: true)
-
-    completed_transaction_edition.organ_donor_registration_url = "https://www.organdonation.nhs.uk/registration/"
-    completed_transaction_edition.save!
-
-    assert_equal "https://www.organdonation.nhs.uk/registration/",
-      completed_transaction_edition.reload.organ_donor_registration_url
-  end
-
-  test "invalid if organ_donor_registration_url is not specified when promotion is on" do
-    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition,
-      promote_organ_donor_registration: true, organ_donor_registration_url: "")
-
-    assert completed_transaction_edition.invalid?
-    assert_includes completed_transaction_edition.errors[:organ_donor_registration_url], "can't be blank"
+    refute completed_transaction_edition.reload.promotes_something?
   end
 
   test "invalid if promotion_choice_url is not specified when a promotion choice is made" do
@@ -70,48 +52,5 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
 
     assert_equal "register_to_vote", completed_transaction_edition.reload.promotion_choice
     assert_equal "https://www.gov.uk/register-to-vote", completed_transaction_edition.promotion_choice_url
-  end
-
-  test "stores promotion choice and URL on legacy documents" do
-    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition,
-      presentation_toggles: {
-        'organ_donor_registration' => {
-          'promote_organ_donor_registration' => false,
-          'organ_donor_registration_url' => ''
-        },
-      }
-    )
-    completed_transaction_edition.save(validate: false)
-    completed_transaction_edition.reload
-
-    completed_transaction_edition.promotion_choice = "register_to_vote"
-    completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/register-to-vote"
-    completed_transaction_edition.save!
-
-    assert_equal "register_to_vote", completed_transaction_edition.reload.promotion_choice
-    assert_equal "https://www.gov.uk/register-to-vote", completed_transaction_edition.promotion_choice_url
-
-    completed_transaction_edition.promotion_choice = "none"
-    completed_transaction_edition.save!
-
-    assert_equal "none", completed_transaction_edition.reload.promotion_choice
-
-    completed_transaction_edition.promotion_choice = "organ_donor"
-    completed_transaction_edition.promotion_choice_url = "https://www.organdonation.nhs.uk/registration/"
-    completed_transaction_edition.save!
-
-    assert_equal "organ_donor", completed_transaction_edition.reload.promotion_choice
-    assert_equal "https://www.organdonation.nhs.uk/registration/", completed_transaction_edition.promotion_choice_url
-  end
-
-  test "passes through legacy organ donor info" do
-    completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition,
-      promote_organ_donor_registration: true)
-
-    completed_transaction_edition.organ_donor_registration_url = "https://www.organdonation.nhs.uk/registration/"
-    completed_transaction_edition.save!
-
-    assert_equal "organ_donor", completed_transaction_edition.reload.promotion_choice
-    assert_equal "https://www.organdonation.nhs.uk/registration/", completed_transaction_edition.promotion_choice_url
   end
 end


### PR DESCRIPTION
There were two api's relating to promotion data. This removes one
leaving a single api.

There will be a migration to tidy up the data in the [Publisher PR](alphagov/publisher#484).

Corresponding PR's:
https://github.com/alphagov/frontend/pull/972
https://github.com/alphagov/publisher/pull/484
https://github.com/alphagov/govuk_content_api/pull/248

[Trello card](https://trello.com/c/QEjTaHBW/408-clean-up-legacy-promo-storage)