### PR TITLE
Bump to version 37.0.0

### DIFF
--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "36.0.0"
+  VERSION = "37.0.0"
 end


### PR DESCRIPTION
We removed the old style API for promotions. See https://trello.com/c/QEjTaHBW/408-clean-up-legacy-promo-storage for details