### PR TITLE
Bump Gem to 38.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 38.0.0
+
+- Removed LocalInteraction model as this information is now obtained from Local
+Links Manager [#389](https://github.com/alphagov/govuk_content_models/pull/389)
+
+## 37.0.0
+
+- Removed old style (organ donor registration) promotion code [#387](https://github.com/alphagov/govuk_content_models/pull/387)
+
 ## 36.0.0
 
 - Remove fields from LocalAuthority

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "37.0.0"
+  VERSION = "38.0.0"
 end


### PR DESCRIPTION
We've removed the LocalInteraction model as this information is now provided by
Local Links Manager.

See https://trello.com/c/opAHOMr4/443-4-of-4-delete-old-ldg-import-into-publisher-and-related-code-3