### PR TITLE
Remove emergency publish event

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -86,10 +86,6 @@ module Workflow
         transition [:ready, :scheduled_for_publishing] => :published
       end
 
-      event :emergency_publish do
-        transition draft: :published
-      end
-
       event :archive do
         transition all => :archived, :unless => :archived?
       end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -890,12 +890,6 @@ class EditionTest < ActiveSupport::TestCase
     refute edition.can_publish?
   end
 
-  test "a draft edition can be emergency published" do
-    edition = FactoryGirl.create(:guide_edition, panopticon_id: @artefact.id, state: "draft")
-    assert edition.can_emergency_publish?
-  end
-
-
   # test denormalisation
 
   test "should denormalise an edition with an assigned user and action requesters" do


### PR DESCRIPTION
This event is not being referenced anywhere in Publisher or Panopticon.
The code appears to have been copied over from Publisher in May 2012, 
and it is not being used in the UI or anywhere else. We remove it entirely 
to avoid future confusion around this event.