### PR TITLE
Add 'skip review' workflow

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -28,7 +28,7 @@ module Workflow
         edition.publish_at = nil
       end
 
-      before_transition on: [:approve_review, :request_amendments] do |edition, transition|
+      before_transition on: [:approve_review, :skip_review, :request_amendments] do |edition, _transition|
         edition.reviewer = nil
       end
 
@@ -54,6 +54,10 @@ module Workflow
 
       event :request_amendments do
         transition [:fact_check_received, :in_review, :ready, :fact_check] => :amends_needed
+      end
+
+      event :skip_review do
+        transition in_review: :ready
       end
 
       # Editions can optionally be sent out for fact check

--- a/lib/govuk_content_models/action_processors.rb
+++ b/lib/govuk_content_models/action_processors.rb
@@ -18,6 +18,7 @@ module GovukContentModels
       publish: 'PublishProcessor',
       archive: 'ArchiveProcessor',
       new_version: 'NewVersionProcessor',
+      skip_review: 'SkipReviewProcessor',
     }
   end
 end

--- a/lib/govuk_content_models/action_processors/skip_review_processor.rb
+++ b/lib/govuk_content_models/action_processors/skip_review_processor.rb
@@ -1,0 +1,9 @@
+module GovukContentModels
+  module ActionProcessors
+    class SkipReviewProcessor < BaseProcessor
+      def process?
+        actor.permissions.include?("skip_review")
+      end
+    end
+  end
+end

--- a/lib/govuk_content_models/test_helpers/action_processor_helpers.rb
+++ b/lib/govuk_content_models/test_helpers/action_processor_helpers.rb
@@ -34,6 +34,10 @@ module GovukContentModels
           publish_at: action_attributes[:publish_at] || Time.zone.now.utc,
           comment: action_attributes[:comment] || 'Schedule!' })
       end
+
+      def skip_review(user, edition)
+        user.progress(edition, request_type: :skip_review, comment: "Skipping review as this is an out of hours urgent update.")
+      end
     end
   end
 end

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -149,6 +149,21 @@ class WorkflowTest < ActiveSupport::TestCase
     assert edition.can_publish?
   end
 
+  test "skip review workflow" do
+    user = FactoryGirl.create(:user, name: "Ben", permissions: ["skip_review"])
+    other = FactoryGirl.create(:user, name: "Ben", permissions: ["signin"])
+
+    edition = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: @artefact.id)
+
+    assert edition.can_request_review?
+    request_review(user, edition)
+    assert edition.can_skip_review?
+    refute skip_review(other, edition)
+    assert skip_review(user, edition)
+    assert edition.ready?
+    assert edition.can_publish?
+  end
+
   test "when fact check has been initiated it can be skipped" do
     user = FactoryGirl.create(:user, name: "Ben")
     other_user = FactoryGirl.create(:user, name: "James")


### PR DESCRIPTION
Part of https://trello.com/c/r7YfHVzG/282-add-force-publish-to-mainstream-medium
Users with specific permissions should be able to skip the review
step when urgent content requests need to be made.

Publisher PR associated with this workflow change https://github.com/alphagov/publisher/pull/513