### PR TITLE
Release version 42.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
-## Unreleased
+## 42.0.0
 
-- Remove everything related to tagging and related links. We now use the content 
+- Remove everything related to tagging and related links. We now use the content
   store for this.
 
 ## 41.1.1

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "41.1.1"
+  VERSION = "42.0.0"
 end


### PR DESCRIPTION
Removes everything related to tagging and related links. We now use the content store for this.