### PR TITLE
Remove test files from the built gem

### DIFF
--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -8,9 +8,8 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Shared models for Panopticon and Publisher, as a Rails Engine}
   gem.homepage      = "https://github.com/alphagov/govuk_content_models"
 
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = `git ls-files`.split($\).reject { |f| f.include?('test/') }
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "govuk_content_models"
   gem.require_paths = ["lib", "app"]
   gem.version       = GovukContentModels::VERSION


### PR DESCRIPTION
When the test/spec directory is mentioned in the gemspec it actually
builds the gem with those files.

There's also no reason to send the test files to production.

### Before


<img width="414" alt="screen shot 2016-12-16 at 11 46 57" src="https://cloud.githubusercontent.com/assets/136777/21261933/5c53f604-c386-11e6-85ce-321cf870eab5.png">

### After


<img width="538" alt="screen shot 2016-12-16 at 11 53 36" src="https://cloud.githubusercontent.com/assets/136777/21261932/5c4f48f2-c386-11e6-8fe5-c86b7cfe8373.png">


