### PR TITLE
Bump version to 42.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 42.0.1
+
+- Fix bug in Attachable which prevents the upload of attachments.
+- Remove test files from the built gem.
+
 ## 42.0.0
 
 - Remove everything related to tagging and related links. We now use the content

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "42.0.0"
+  VERSION = "42.0.1"
 end


### PR DESCRIPTION
- Fix bug in Attachable which prevents the upload of attachments.
- Remove test files from the built gem.