### PR TITLE
Remove panopticon from apps that use this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 A gem containing the shared models for the old GOV.UK publishing applications:
 
-- [Panopticon](https://github.com/alphagov/panopticon)
-- [Publisher](https://github.com/alphagov/publisher).
+- [Publisher](https://github.com/alphagov/publisher)
 - [Content API](https://github.com/alphagov/govuk_content_api)
 


### PR DESCRIPTION
We're retiring panopticon: 

https://trello.com/c/dGPNmVub