### PR TITLE
Bump version to 43.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 43.0.0
+
+- Bump Ruby version to 2.2.3
+- Change the default_presentation_toggles promotion choice to `none` for Completed Transactions
+- Remove panopticon from apps that use this repo
+
 ## 42.0.1
 
 - Fix bug in Attachable which prevents the upload of attachments.

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "42.0.1"
+  VERSION = "42.1.0"
 end


### PR DESCRIPTION
- Bump Ruby version to 2.2.3
- Change the default_presentation_toggles promotion choice to `none` for Completed Transactions
- Remove panopticon from apps that use this repo