### PR TITLE
Expose the display_start_time of Downtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Expose the display_start_time of a Downtime object
+
 ## 43.0.0
 
 - Bump Ruby version to 2.2.3

--- a/app/models/downtime.rb
+++ b/app/models/downtime.rb
@@ -17,7 +17,11 @@ class Downtime
   end
 
   def publicise?
-    Time.zone.now.between?(start_time.yesterday.at_midnight, end_time)
+    Time.zone.now.between?(display_start_time, end_time)
+  end
+
+  def display_start_time
+    start_time.yesterday.at_midnight
   end
 
   private

--- a/test/models/downtime_test.rb
+++ b/test/models/downtime_test.rb
@@ -64,7 +64,7 @@ class DowntimeTest < ActiveSupport::TestCase
   end
 
   context "publicising downtime" do
-    should "start at midnight a day before it is scheduled" do
+    should "start at display_start_time" do
       now = Time.zone.parse("2015-01-01")
       Timecop.freeze(now) do
         downtime = FactoryGirl.build(:downtime)
@@ -90,4 +90,12 @@ class DowntimeTest < ActiveSupport::TestCase
     end
   end
 
+  context "#display_start_time" do
+    should "return the datetime of midnight the day before it's scheduled" do
+      downtime = FactoryGirl.build(:downtime)
+      downtime.start_time = Time.zone.parse("2015-01-02 03:00")
+      expected_start_time = Time.zone.parse("2015-01-01 00:00")
+      assert_equal expected_start_time, downtime.display_start_time
+    end
+  end
 end


### PR DESCRIPTION
To maximise code reuse, we've exposed the display_start_time property of a Downtime.