### PR TITLE
Add retired formats to Artefact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Add list of retired formats to Artefact
+
 ## 43.0.1
 
 - Expose the display_start_time of a Downtime object

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -118,6 +118,8 @@ class Artefact
                                   "written_statement"],
   }.freeze
 
+  RETIRED_FORMATS = ["video"]
+
   FORMATS = FORMATS_BY_DEFAULT_OWNING_APP.values.flatten
 
   def self.default_app_for_format(format)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -100,6 +100,7 @@ class Edition
   end
 
   def can_create_new_edition?
+    return false if retired_format?
     !scheduled_for_publishing? && subsequent_siblings.in_progress.empty?
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -103,6 +103,10 @@ class Edition
     !scheduled_for_publishing? && subsequent_siblings.in_progress.empty?
   end
 
+  def retired_format?
+    Artefact::RETIRED_FORMATS.include? format.downcase
+  end
+
   def major_updates_in_series
     history.published.major_updates
   end

--- a/test/models/video_edition_test.rb
+++ b/test/models/video_edition_test.rb
@@ -46,19 +46,4 @@ class VideoEditionTest < ActiveSupport::TestCase
       assert_equal expected, v.whole_body
     end
   end
-
-  should "clone extra fields when cloning edition" do
-    video = FactoryGirl.create(:video_edition,
-                               :panopticon_id => @artefact.id,
-                               :state => "published",
-                               :video_url => "http://www.youtube.com/watch?v=qySFp3qnVmM",
-                               :video_summary => "Coke smoothie",
-                               :body => "Description of video")
-
-    new_video = video.build_clone
-
-    assert_equal video.video_url, new_video.video_url
-    assert_equal video.video_summary, new_video.video_summary
-    assert_equal video.body, new_video.body
-  end
 end


### PR DESCRIPTION
We are retiring some Publisher formats, so we decided to keep a list of them.