### PR TITLE
Validate that completed transaction page slugs start with `done/`

### DIFF
--- a/app/validators/slug_validator.rb
+++ b/app/validators/slug_validator.rb
@@ -53,10 +53,11 @@ protected
 
   class DonePageValidator < InstanceValidator
     def applicable?
-      starts_with?("done/")
+      of_kind?("completed_transaction")
     end
 
     def validate!
+      record.errors[attribute] << "Done page slugs must have a done/ prefix" unless starts_with?("done/")
       url_after_first_slash_is_valid_slug!
     end
   end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -19,12 +19,7 @@ class ArtefactTest < ActiveSupport::TestCase
       assert a.errors[:slug].any?
     end
 
-    should "allow slashes in slugs when the namespace is 'done'" do
-      a = FactoryGirl.build(:artefact, slug: "done/its-a-nice-day")
-      assert a.valid?
-    end
-
-    should "not allow slashes in slugs when the namespace is not 'done'" do
+    should "not allow slashes in slugs when the namespace is not 'done' or 'help'" do
       a = FactoryGirl.build(:artefact, slug: "something-else/its-a-nice-day")
       refute a.valid?
       assert a.errors[:slug].any?
@@ -32,6 +27,16 @@ class ArtefactTest < ActiveSupport::TestCase
 
     should "allow travel-advice to have a slug prefixed with 'foreign-travel-advice/'" do
       a = FactoryGirl.build(:artefact, slug: "foreign-travel-advice/aruba", kind: "travel-advice")
+      assert a.valid?
+    end
+
+    should "allow help pages to have a slug prefixed with 'help/'" do
+      a = FactoryGirl.build(:artefact, slug: "help/a-page", kind: "help_page")
+      assert a.valid?
+    end
+
+    should "allow done pages to have a slug prefixed with 'done/'" do
+      a = FactoryGirl.build(:artefact, slug: "done/a-page", kind: "completed_transaction")
       assert a.valid?
     end
 

--- a/test/validators/slug_validator_test.rb
+++ b/test/validators/slug_validator_test.rb
@@ -33,10 +33,6 @@ class SlugTest < ActiveSupport::TestCase
       # Gems like friendly_id use -- to de-dup slug collisions
       assert document_with_slug("normal-slug--1").valid?
     end
-
-    should "allow a done page slug" do
-      assert document_with_slug("done/normal-slug").valid?
-    end
   end
 
   context "Foreign travel advice pages" do
@@ -57,6 +53,17 @@ class SlugTest < ActiveSupport::TestCase
 
     should "not allow non-help pages to start with help/" do
       refute document_with_slug("help/test", kind: "answer").valid?
+    end
+  end
+
+  context "Done pages" do
+    should "start with done/" do
+      refute document_with_slug("test", kind: "completed_transaction").valid?
+      assert document_with_slug("done/test", kind: "completed_transaction").valid?
+    end
+
+    should "not allow non-done pages to start with done/" do
+      refute document_with_slug("done/test", kind: "answer").valid?
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/iP0NDr8I/702-add-validation-for-done-slug-prefix-for-completed-transactions-in-publisher