### PR TITLE
Add Campaign to retired formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Add Campaign to the list of retired formats
+
 ## 44.0.1
 
 - Validate that completed transaction page slugs start with `done/`

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -118,7 +118,7 @@ class Artefact
                                   "written_statement"],
   }.freeze
 
-  RETIRED_FORMATS = %w[video programme]
+  RETIRED_FORMATS = %w[campaign programme video]
 
   FORMATS = FORMATS_BY_DEFAULT_OWNING_APP.values.flatten
 

--- a/test/models/campaign_edition_test.rb
+++ b/test/models/campaign_edition_test.rb
@@ -41,30 +41,6 @@ class CampaignEditionTest < ActiveSupport::TestCase
     assert_equal campaign.body, campaign.whole_body
   end
 
-  should "clone extra fields when cloning edition" do
-    campaign = FactoryGirl.create(:campaign_edition,
-                               :panopticon_id => @artefact.id,
-                               :state => "published",
-                               :body => "I'm very campaignful",
-                               :large_image_id => "large-image",
-                               :medium_image_id => "medium-image",
-                               :small_image_id => "small-image",
-                               :organisation_formatted_name => "Driver & Vehicle\nLicensing\nAgency",
-                               :organisation_url => "/government/organisations/driver-and-vehicle-licensing-agency",
-                               :organisation_brand_colour => "department-for-transport",
-                               :organisation_crest => "single-identity" )
-
-    new_campaign = campaign.build_clone
-    assert_equal campaign.body, new_campaign.body
-    assert_equal campaign.large_image_id, new_campaign.large_image_id
-    assert_equal campaign.medium_image_id, new_campaign.medium_image_id
-    assert_equal campaign.small_image_id, new_campaign.small_image_id
-    assert_equal campaign.organisation_formatted_name, new_campaign.organisation_formatted_name
-    assert_equal campaign.organisation_url, new_campaign.organisation_url
-    assert_equal campaign.organisation_brand_colour, new_campaign.organisation_brand_colour
-    assert_equal campaign.organisation_crest, new_campaign.organisation_crest
-  end
-
   should "be not valid with an organisation brand colour from outside the list" do
     campaign = FactoryGirl.build(:campaign_edition, :panopticon_id => @artefact.id)
     campaign.organisation_brand_colour = "something-else"


### PR DESCRIPTION
The Campaign format is being retired, so we add it to the list of retired
formats.

https://trello.com/c/KCyghhGM/706-retire-campaign-format