### PR TITLE
Fix #retired_format?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 44.2.1
+
+- Use #underscore instead of #downcase to convert retired format names to string
+
 ## 44.2.0
 
 - Add Business Support to the list of retired formats

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -105,7 +105,7 @@ class Edition
   end
 
   def retired_format?
-    Artefact::RETIRED_FORMATS.include? format.downcase
+    Artefact::RETIRED_FORMATS.include? format.underscore
   end
 
   def major_updates_in_series


### PR DESCRIPTION
The method did not handle classes with compound names the same way we do.
BusinessSupport.downcase returns 'businesssupport' when we need it to be
'business_support'.

https://trello.com/c/LsSYEpmg/705-retire-business-support-format