### PR TITLE
[DO NOT MERGE] Rename lgil_override to lgil_code

### DIFF
--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -4,6 +4,7 @@ require "edition"
 class LocalTransactionEdition < Edition
   field :lgsl_code, type: Integer
   field :lgil_override, type: Integer
+  field :lgil_code, type: Integer
   field :introduction, type: String
   field :more_information, type: String
   field :need_to_know, type: String
@@ -11,6 +12,7 @@ class LocalTransactionEdition < Edition
   GOVSPEAK_FIELDS = [:introduction, :more_information, :need_to_know]
 
   validate :valid_lgsl_code
+  validates :lgil_code, numericality: { only_integer: true, message: "can only be whole number between 0 and 999." }
 
   def valid_lgsl_code
     if ! self.service


### PR DESCRIPTION
All local transactions will be assigned to a lgil_code by default.
Once this is done, the lgil_override field will be removed.

https://trello.com/c/RnJC1d7a/5-assign-lgil-codes-to-all-local-transactions

DO NOT MERGE... until PRs in other repos (Publisher, etc.) are ready.