### PR TITLE
Add mandatory lgil_code

### DIFF
--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -4,6 +4,7 @@ require "edition"
 class LocalTransactionEdition < Edition
   field :lgsl_code, type: Integer
   field :lgil_override, type: Integer
+  field :lgil_code, type: Integer
   field :introduction, type: String
   field :more_information, type: String
   field :need_to_know, type: String
@@ -11,6 +12,7 @@ class LocalTransactionEdition < Edition
   GOVSPEAK_FIELDS = [:introduction, :more_information, :need_to_know]
 
   validate :valid_lgsl_code
+  validates :lgil_code, numericality: { only_integer: true, message: "can only be whole number between 0 and 999." }
 
   def valid_lgsl_code
     if ! self.service

--- a/test/models/artefact_action_test.rb
+++ b/test/models/artefact_action_test.rb
@@ -96,7 +96,7 @@ class ArtefactActionTest < ActiveSupport::TestCase
     assert_equal ["create", "update"], @artefact.actions.map(&:action_type)
 
     assert_equal 'TaggingUpdater', @artefact.actions.last.task_performed_by
-    assert_equal nil, @artefact.actions.last.user
+    assert_nil @artefact.actions.last.user
   end
 
   test "saving as a user should record a user action" do

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -168,7 +168,7 @@ class ArtefactTest < ActiveSupport::TestCase
 
         @artefact.need_id = nil
 
-        assert_equal nil, @artefact.need_id
+        assert_nil @artefact.need_id
         assert_equal %w(100044 100045), @artefact.need_ids
       end
     end
@@ -428,7 +428,7 @@ class ArtefactTest < ActiveSupport::TestCase
 
     # Make the edition invalid, check that it persisted the invalid state
     edition.update_attribute(:title, nil)
-    assert_equal(nil, edition.reload.title)
+    assert_nil edition.reload.title
 
     artefact.update_attributes_as(user1, state: "archived")
     artefact.save!

--- a/test/models/business_support_edition_test.rb
+++ b/test/models/business_support_edition_test.rb
@@ -101,7 +101,7 @@ class BusinessSupportEditionTest < ActiveSupport::TestCase
         @support.send("#{field}=", "")
         @support.save!
         s = BusinessSupportEdition.find(@support.id)
-        assert_equal nil, s.send(field)
+        assert_nil s.send(field)
       end
     end
   end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1060,7 +1060,7 @@ class EditionTest < ActiveSupport::TestCase
     should 'return nil if there is no major update in the edition series' do
       edition1 = FactoryGirl.create(:answer_edition, major_change: false,
                                                      state: 'published')
-      assert_equal nil, edition1.latest_change_note
+      assert_nil edition1.latest_change_note
     end
   end
 
@@ -1095,7 +1095,7 @@ class EditionTest < ActiveSupport::TestCase
                                                      updated_at: 1.minute.ago,
                                                      state: 'draft')
 
-      assert_equal nil, edition1.public_updated_at
+      assert_nil edition1.public_updated_at
     end
   end
 

--- a/test/models/local_transaction_edition_test.rb
+++ b/test/models/local_transaction_edition_test.rb
@@ -23,15 +23,15 @@ class LocalTransactionEditionTest < ActiveSupport::TestCase
 
 
   test "should validate on save that a LocalService exists for that lgsl_code" do
-    s = LocalService.create!(lgsl_code: BINS, providing_tier: %w{county unitary})
+    service = LocalService.create!(lgsl_code: BINS, providing_tier: %w{county unitary})
 
-    lt = LocalTransactionEdition.new(lgsl_code: NONEXISTENT, title: "Foo", slug: "foo", panopticon_id: @artefact.id)
-    lt.save
-    assert !lt.valid?
+    local_transaction = LocalTransactionEdition.new(lgsl_code: NONEXISTENT, lgil_code: 1, title: "Foo", slug: "foo", panopticon_id: @artefact.id)
+    local_transaction.save
+    assert !local_transaction.valid?
 
-    lt = LocalTransactionEdition.new(lgsl_code: s.lgsl_code, title: "Bar", slug: "bar", panopticon_id: @artefact.id)
-    lt.save
-    assert lt.valid?
-    assert lt.persisted?
+    local_transaction = LocalTransactionEdition.new(lgsl_code: service.lgsl_code, lgil_code: 1, title: "Bar", slug: "bar", panopticon_id: @artefact.id)
+    local_transaction.save
+    assert local_transaction.valid?
+    assert local_transaction.persisted?
   end
 end

--- a/test/models/travel_advice_edition_test.rb
+++ b/test/models/travel_advice_edition_test.rb
@@ -364,38 +364,39 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
       Timecop.freeze(1.days.ago) do
         # this is done to make sure there's a significant difference in time
         # between creating the edition and it being published
-        @ed = FactoryGirl.create(:travel_advice_edition, :country_slug => 'aruba')
+        @edition = FactoryGirl.create(:travel_advice_edition, :country_slug => 'aruba')
       end
     end
 
     should "be updated to published time when edition is published" do
-      @ed.change_description = "Did some stuff"
-      @ed.publish!
-      assert_equal @ed.published_at, @ed.reviewed_at
+      @edition.change_description = "Did some stuff"
+      @edition.publish!
+      assert_equal @edition.published_at, @edition.reviewed_at
     end
 
     should "be set to the previous version's reviewed_at when a minor update is published" do
-      @ed.minor_update = true
-      @ed.publish!
-      assert_equal @published.reviewed_at, @ed.reviewed_at
+      @edition.minor_update = true
+      @edition.publish!
+      assert_equal @published.reviewed_at, @edition.reviewed_at
     end
 
     should "be able to be updated without affecting other dates" do
-      published_at = @ed.published_at
+      @edition.published_at = Time.zone.now
+      @edition.save!
       Timecop.freeze(1.day.from_now) do
-        @ed.reviewed_at = Time.zone.now
-        assert_equal published_at, @ed.published_at
+        @edition.reviewed_at = Time.zone.now
+        assert_equal @edition.published_at, @edition.published_at
       end
     end
 
     should "be able to update reviewed_at on a published edition" do
-      @ed.minor_update = true
-      @ed.publish!
+      @edition.minor_update = true
+      @edition.publish!
       Timecop.freeze(1.day.from_now) do
         new_time = Time.zone.now
-        @ed.reviewed_at = new_time
-        @ed.save!
-        assert_equal new_time.utc.to_i, @ed.reviewed_at.to_i
+        @edition.reviewed_at = new_time
+        @edition.save!
+        assert_equal new_time.utc.to_i, @edition.reviewed_at.to_i
       end
     end
   end

--- a/test/models/travel_advice_edition_test.rb
+++ b/test/models/travel_advice_edition_test.rb
@@ -253,7 +253,7 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
       should "do nothing if country_slug is not set" do
         ed = TravelAdviceEdition.new(:country_slug => '')
         ed.valid?
-        assert_equal nil, ed.version_number
+        assert_nil ed.version_number
       end
     end
 
@@ -310,7 +310,7 @@ class TravelAdviceEditionTest < ActiveSupport::TestCase
     end
 
     should "return nil if there is no previous version" do
-      assert_equal nil, @ed1.previous_version
+      assert_nil @ed1.previous_version
     end
   end
 


### PR DESCRIPTION
All local transactions will be assigned to a lgil_code by default. This makes it mandatory, and checks that it is an integer. Once this is done, the lgil_override field will be removed.

This also silences assert_nil warnings, and corrects ruby styleguide violations that were encountered along the way.

https://trello.com/c/RnJC1d7a/5-assign-lgil-codes-to-all-local-transactions
