### PR TITLE
Allow for redirects not starting with /

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Allow redirect_url to not start with / and including //
+
 ## 44.3.0
 
 - Add mandatory lgil_code field for local transactions

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -344,7 +344,7 @@ class Artefact
 
   def valid_redirect_url_path?(target)
     URI.parse(target)
-    target.starts_with?("/") && target !~ %r{//} && target !~ %r{./\z}
+    target !~ %r{[^:]//}
   rescue URI::InvalidURIError
     false
   end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -239,9 +239,6 @@ class ArtefactTest < ActiveSupport::TestCase
   should "validate redirect_url" do
     artefact = FactoryGirl.create(:artefact)
 
-    artefact.redirect_url = "foobar"
-    refute artefact.valid?
-
     artefact.redirect_url = "/foobar"
     assert artefact.valid?
 
@@ -251,13 +248,12 @@ class ArtefactTest < ActiveSupport::TestCase
     artefact.redirect_url = "/foobar#chapter"
     assert artefact.valid?
 
-    artefact.redirect_url = "http://foo.bar/"
-    refute artefact.valid?
+    artefact.redirect_url = "http://foo.bar.gov.uk/"
+    assert artefact.valid?
 
     [
       "\jkhsdfgjkhdjskfgh//fdf#th",
       "not a URL path",
-      "bar/baz",
       "/foo//bar",
     ].each do |invalid_path|
       artefact.redirect_url = invalid_path


### PR DESCRIPTION
The Publishing API is more permissive than the
govuk_content_models. This change is motivated by getting support for
redirecting to campaigns (e.g. https://name.campaign.gov.uk/ ) in to
Publisher.