### PR TITLE
Remove redirect_url validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Remove redirect_url validation.
+
 ## 44.3.0
 
 - Add mandatory lgil_code field for local transactions

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -155,7 +155,6 @@ class Artefact
   validates_with CannotEditSlugIfEverPublished
   validate :validate_prefixes_and_paths
   validate :format_of_new_need_ids, if: :need_ids_changed?
-  validate :validate_redirect_url
 
   def self.in_alphabetical_order
     order_by(name: :asc)
@@ -331,20 +330,6 @@ class Artefact
     return false unless path.starts_with?("/")
     uri = URI.parse(path)
     uri.path == path && path !~ %r{//} && path !~ %r{./\z}
-  rescue URI::InvalidURIError
-    false
-  end
-
-  def validate_redirect_url
-    return unless self.redirect_url.present?
-    unless valid_redirect_url_path?(self.redirect_url)
-      errors[:redirect_url] << "is not a valid redirect target"
-    end
-  end
-
-  def valid_redirect_url_path?(target)
-    URI.parse(target)
-    target.starts_with?("/") && target !~ %r{//} && target !~ %r{./\z}
   rescue URI::InvalidURIError
     false
   end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -236,35 +236,6 @@ class ArtefactTest < ActiveSupport::TestCase
     end
   end
 
-  should "validate redirect_url" do
-    artefact = FactoryGirl.create(:artefact)
-
-    artefact.redirect_url = "foobar"
-    refute artefact.valid?
-
-    artefact.redirect_url = "/foobar"
-    assert artefact.valid?
-
-    artefact.redirect_url = "/foobar?an=argument"
-    assert artefact.valid?
-
-    artefact.redirect_url = "/foobar#chapter"
-    assert artefact.valid?
-
-    artefact.redirect_url = "http://foo.bar/"
-    refute artefact.valid?
-
-    [
-      "\jkhsdfgjkhdjskfgh//fdf#th",
-      "not a URL path",
-      "bar/baz",
-      "/foo//bar",
-    ].each do |invalid_path|
-      artefact.redirect_url = invalid_path
-      refute artefact.valid?
-    end
-  end
-
   test "should translate kind into internally normalised form" do
     a = Artefact.new(kind: "benefit / scheme")
     a.normalise


### PR DESCRIPTION
Now that govuk_content_models is becoming less relevant as the
Publishing API and GOV.UK Content Schemas are used for validation, the
validation in govuk_content_models is both no longer necessary, and if
it gets out of sync, can become problematic.