### PR TITLE
Only run CI build on instances with Mongodb 2.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 REPOSITORY = 'govuk_content_models'
 
-node {
+node('mongodb-2.4') {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
   try {


### PR DESCRIPTION
Tests have been failing due to them running on the wrong version of mongo.

More information here: alphagov/manuals-publisher#976

https://trello.com/c/H3gARFuk/56-upgrade-publisher-to-rails-5