### PR TITLE
Remove references to the Content API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # GOV.UK Content Models
 
-A gem containing the shared models for the old GOV.UK publishing applications:
+A gem containing the shared models for the old GOV.UK [Publisher][publisher] application.
 
-- [Publisher](https://github.com/alphagov/publisher)
-- [Content API](https://github.com/alphagov/govuk_content_api)
-
+[Publisher]: https://github.com/alphagov/publisher


### PR DESCRIPTION
The [`content_api`](https://github.com/alphagov/govuk_content_api) has
been retired, and all content has been migrated to the
[`content_store`](https://github.com/alphagov/content-store).

Therefore, we can remove all references to the Content API, and rely
solely on the Content Store.

### Trello

https://trello.com/c/TsUsUwD7/153-remove-documentation-on-content-api