### PR TITLE
Bump gem to 46.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 46.0.0
+
+- Remove references to Whitehall
+
 ## 45.0.0
 
 - Bump dependencies to rails 5.0.2, rack 2.0.1, factory_girl to 4.8.0, mongoid to 6.1 and gds-sso to 13.2

--- a/lib/govuk_content_models/version.rb
+++ b/lib/govuk_content_models/version.rb
@@ -1,4 +1,4 @@
 module GovukContentModels
   # Changing this causes Jenkins to tag and release the gem into the wild
-  VERSION = "45.0.0"
+  VERSION = "46.0.0"
 end


### PR DESCRIPTION
To include latest changes that remove Whitehall references, see https://github.com/alphagov/govuk_content_models/pull/435