### PR TITLE
Pin mongoid to 6.1.0

### DIFF
--- a/govuk_content_models.gemspec
+++ b/govuk_content_models.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gds-sso",          "~> 13.2"
   gem.add_dependency "govspeak",         "~> 3.1"
-  gem.add_dependency "mongoid",          "~> 6.1"
+  gem.add_dependency "mongoid",          "6.1.0"
   gem.add_dependency "state_machines",   "~> 0.4"
   gem.add_dependency "state_machines-mongoid", "~> 0.1"
   gem.add_dependency "plek"


### PR DESCRIPTION
- We're seeing a bug with code for `SimpleSmartAnswerEdition`s that only
  occurs in 6.1.1, and our `~> 6.1` pinning was installing `6.1.1` as
  the latest version. While we wait for time to fix this bug
  (```undefined method `options' for class
  `SimpleSmartAnswerEdition::Node' (NameError)```), use a patch version
  lower of Mongoid to allow us to progress with current work.

(cc @boffbowsh)