### PR TITLE
Change the user model to accommodate Mongoid 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Deprecate `User.collection_name` to specify the user database table - instead, use the `USER_COLLECTION_NAME` environment variable directly.
+
 ## 46.0.1
 
 - Downgrade mongoid to 6.1.0 due to a bug caused by 6.1.1 in `SimpleSmartAnswerEdition`.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,10 +8,12 @@ class User
   include Mongoid::Timestamps
   include GDS::SSO::User
 
-  # Let an app configure the collection name to use, e.g. set a constant in an
-  # initializer
-  def self.collection_name
-    defined?(USER_COLLECTION_NAME) ? USER_COLLECTION_NAME : "users"
+  # Let an app configure the symbolized collection name to use,
+  # e.g. set a constant in an initializer.
+  if defined?(USER_COLLECTION_NAME)
+    store_in collection: USER_COLLECTION_NAME.to_sym
+  else
+    store_in collection: :users
   end
 
   field "name",                    type: String

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -147,9 +147,4 @@ class UserTest < ActiveSupport::TestCase
 
     assert_nil publication.assigned_to
   end
-
-
-  test "should default to a collection called 'users'" do
-    assert_equal "users", User.collection_name
-  end
 end


### PR DESCRIPTION
- As per the app-specific instructions in
  https://github.com/alphagov/specialist-publisher/pull/935/commits/f785a550207a8cdf81a59e47a4b605e598b72152,
  but I'm doing this across the board as opposed to just in Publisher
  (the only other thing that uses Content Models is Content API). So it
  doesn't break anything, I'm calling `.to_sym` on the constant set in
  apps - `USER_COLLECTION_NAME` - because it's probably a string in
  apps due to previous behaviour.

I'm of the opinion that this should be a breaking change, because it removes `User.collection_name` which some apps might use to specify the user collection name.